### PR TITLE
[Border] Fix malformatted unordered list

### DIFF
--- a/docs/addons/Border/index.md
+++ b/docs/addons/Border/index.md
@@ -2,6 +2,7 @@
 
 **Border** can create and show a border around islands which players cannot pass.  
 The border can be:
+
 - the vanilla world border (using [**WorldBorderAPI**](https://github.com/yannicklamprecht/WorldBorderAPI/releases) plugin)
 - a custom border that shows up when the player is near (visuals can be configured).
 


### PR DESCRIPTION
Currently an unordered list looks like this ([URL](https://docs.bentobox.world/en/latest/addons/Border/)):
![img](https://user-images.githubusercontent.com/17320094/143816272-aa329549-1ec7-41e8-a608-083d6febec9c.png)

I **guess** it is caused because there is no empty line before the enumeration (I checked the Chat addons' doc).