### PR TITLE
docs: update documentation for releases 2026-04-12

### DIFF
--- a/data/flags.csv
+++ b/data/flags.csv
@@ -140,3 +140,4 @@ Visit,ALLOW_VISITS_FLAG,Visit protection,PUMPKIN_PIE,Toggle if island can be vis
 Visit,RECEIVE_VISIT_MESSAGE_FLAG,Receive Visiting Messages,PAPER,Toggle if members should receive a message if someone visits their island.,SETTING,BASIC,true,,
 VoidPortals,VOID_WORLD_TELEPORT_FLAG,Void world teleports,ENDER_PEARL,This allows to toggle ability to teleport to different dimension if player falls in void.,WORLD_SETTING,BASIC,false,,
 Warps,PLACE_WARP,Place Warp,OAK_SIGN,Allows to toggle who can place warp signs on island,PROTECTION,EXPERT,MEMBER_RANK,MEMBER_RANK,OWNER_RANK
+Level,ISLAND_BLOCK_DONATION,Block donation,HOPPER,Allow island members to donate blocks to island level,PROTECTION,BASIC,OWNER_RANK,MEMBER_RANK,OWNER_RANK

--- a/data/placeholders.csv
+++ b/data/placeholders.csv
@@ -122,3 +122,4 @@ TopBlock,aoneblock_island_phase_name_top_<number>,Name of the phase they have re
 TopBlock,aoneblock_island_phase_number_top_<number>,Phase number (e.g. Plains is 1; Underground is 2) at the `<number>` position, 1.0.1
 TopBlock,aoneblock_island_count_top_<number>,Block Count of magic blocks mined this round at the `<number>` position, 1.0.1
 TopBlock,aoneblock_island_lifetime_top_<number>,Lifetime count of magic blocks mined at the `<number>` position, 1.0.1
+Border,Border_color,Current border color (red/green/blue) for the player,4.8.0

--- a/data/release-tracker.json
+++ b/data/release-tracker.json
@@ -1,0 +1,197 @@
+{
+  "last_run": "2026-04-13T06:53:32Z",
+  "repos": {
+    "BentoBox": {
+      "last_checked": "2026-04-13T06:53:32Z",
+      "last_release": "3.14.1",
+      "doc_path": "BentoBox/",
+      "category": "core"
+    },
+    "AcidIsland": {
+      "last_checked": "2026-04-13T06:53:32Z",
+      "last_release": "1.21.0",
+      "doc_path": "gamemodes/AcidIsland/index.md",
+      "category": "gamemode"
+    },
+    "AOneBlock": {
+      "last_checked": "2026-04-13T06:53:32Z",
+      "last_release": "1.23.0",
+      "doc_path": "gamemodes/AOneBlock/index.md",
+      "category": "gamemode"
+    },
+    "Boxed": {
+      "last_checked": "2026-01-13T06:31:47Z",
+      "last_release": "",
+      "doc_path": "gamemodes/Boxed/index.md",
+      "category": "gamemode"
+    },
+    "BSkyBlock": {
+      "last_checked": "2026-01-13T06:31:47Z",
+      "last_release": "",
+      "doc_path": "gamemodes/BSkyBlock/index.md",
+      "category": "gamemode"
+    },
+    "CaveBlock": {
+      "last_checked": "2026-01-13T06:31:47Z",
+      "last_release": "",
+      "doc_path": "gamemodes/CaveBlock/index.md",
+      "category": "gamemode"
+    },
+    "poseidon": {
+      "last_checked": "2026-01-13T06:31:47Z",
+      "last_release": "",
+      "doc_path": "gamemodes/Poseidon/index.md",
+      "category": "gamemode"
+    },
+    "RaftMode": {
+      "last_checked": "2026-01-13T06:31:47Z",
+      "last_release": "",
+      "doc_path": "gamemodes/RaftMode/index.md",
+      "category": "gamemode"
+    },
+    "SkyGrid": {
+      "last_checked": "2026-01-13T06:31:47Z",
+      "last_release": "",
+      "doc_path": "gamemodes/SkyGrid/index.md",
+      "category": "gamemode"
+    },
+    "StrangerRealms": {
+      "last_checked": "2026-01-13T06:31:47Z",
+      "last_release": "",
+      "doc_path": "gamemodes/StrangerRealms/index.md",
+      "category": "gamemode"
+    },
+    "Bank": {
+      "last_checked": "2026-04-13T06:53:32Z",
+      "last_release": "1.9.1",
+      "doc_path": "addons/Bank/index.md",
+      "category": "addon"
+    },
+    "Biomes": {
+      "last_checked": "2026-01-13T06:31:47Z",
+      "last_release": "",
+      "doc_path": "addons/Biomes/index.md",
+      "category": "addon"
+    },
+    "Border": {
+      "last_checked": "2026-04-13T06:53:32Z",
+      "last_release": "4.8.2",
+      "doc_path": "addons/Border/index.md",
+      "category": "addon"
+    },
+    "Challenges": {
+      "last_checked": "2026-04-13T06:53:32Z",
+      "last_release": "1.6.0",
+      "doc_path": "addons/Challenges/index.md",
+      "category": "addon"
+    },
+    "Chat": {
+      "last_checked": "2026-01-13T06:31:47Z",
+      "last_release": "",
+      "doc_path": "addons/Chat/index.md",
+      "category": "addon"
+    },
+    "CheckMeOut": {
+      "last_checked": "2026-01-13T06:31:47Z",
+      "last_release": "",
+      "doc_path": "addons/CheckMeOut/index.md",
+      "category": "addon"
+    },
+    "ControlPanel": {
+      "last_checked": "2026-01-13T06:31:47Z",
+      "last_release": "",
+      "doc_path": "addons/ControlPanel/index.md",
+      "category": "addon"
+    },
+    "DimensionalTrees": {
+      "last_checked": "2026-01-13T06:31:47Z",
+      "last_release": "",
+      "doc_path": "addons/DimensionalTrees/index.md",
+      "category": "addon"
+    },
+    "ExtraMobs": {
+      "last_checked": "2026-01-13T06:31:47Z",
+      "last_release": "",
+      "doc_path": "addons/ExtraMobs/index.md",
+      "category": "addon"
+    },
+    "FarmersDance": {
+      "last_checked": "2026-01-13T06:31:47Z",
+      "last_release": "",
+      "doc_path": "addons/FarmersDance/index.md",
+      "category": "addon"
+    },
+    "Greenhouses": {
+      "last_checked": "2026-01-13T06:31:47Z",
+      "last_release": "",
+      "doc_path": "addons/Greenhouses/index.md",
+      "category": "addon"
+    },
+    "InvSwitcher": {
+      "last_checked": "2026-04-13T06:53:32Z",
+      "last_release": "1.17.0",
+      "doc_path": "addons/InvSwitcher/index.md",
+      "category": "addon"
+    },
+    "IslandFly": {
+      "last_checked": "2026-01-13T06:31:47Z",
+      "last_release": "",
+      "doc_path": "addons/IslandFly/index.md",
+      "category": "addon"
+    },
+    "Level": {
+      "last_checked": "2026-04-13T06:53:32Z",
+      "last_release": "2.24.0",
+      "doc_path": "addons/Level/index.md",
+      "category": "addon"
+    },
+    "Likes": {
+      "last_checked": "2026-01-13T06:31:47Z",
+      "last_release": "",
+      "doc_path": "addons/Likes/index.md",
+      "category": "addon"
+    },
+    "Limits": {
+      "last_checked": "2026-04-13T06:53:32Z",
+      "last_release": "1.28.1",
+      "doc_path": "addons/Limits/index.md",
+      "category": "addon"
+    },
+    "MagicCobblestoneGenerator": {
+      "last_checked": "2026-01-13T06:31:47Z",
+      "last_release": "",
+      "doc_path": "addons/MagicCobblestoneGenerator/index.md",
+      "category": "addon"
+    },
+    "TopBlock": {
+      "last_checked": "2026-01-13T06:31:47Z",
+      "last_release": "",
+      "doc_path": "addons/TopBlock/index.md",
+      "category": "addon"
+    },
+    "TwerkingForTrees": {
+      "last_checked": "2026-01-13T06:31:47Z",
+      "last_release": "",
+      "doc_path": "addons/TwerkingForTrees/index.md",
+      "category": "addon"
+    },
+    "Upgrades": {
+      "last_checked": "2026-04-13T06:53:32Z",
+      "last_release": "1.0.1",
+      "doc_path": "addons/Upgrades/index.md",
+      "category": "addon"
+    },
+    "Visit": {
+      "last_checked": "2026-01-13T06:31:47Z",
+      "last_release": "",
+      "doc_path": "addons/Visit/index.md",
+      "category": "addon"
+    },
+    "Warps": {
+      "last_checked": "2026-04-13T06:53:32Z",
+      "last_release": "1.19.0",
+      "doc_path": "addons/Warps/index.md",
+      "category": "addon"
+    }
+  }
+}

--- a/docs/addons/Bank/index.md
+++ b/docs/addons/Bank/index.md
@@ -115,6 +115,16 @@ permissions:
 ## Like this addon?
 You can [sponsor](https://github.com/sponsors/tastybento) to get more addons like this and make this one better!
 
+## Changelog
+
+??? note "What's new in v1.9.1"
+    **Released:** 2026-03-28
+
+    - **Top island name placeholders.** `%Bank_[gamemode]_top_island_<number>%` now exposes the island name (not just the owner name) for each leaderboard position. Island names are cached alongside owner names and balances.
+    - ⚙️ Interest compounding documentation and config comments corrected — the `compound-periods-per-year` calculation had an off-by-one that caused slightly incorrect compound interest. Update your config comments by replacing the old jar.
+
+    [Release v1.9.1](https://github.com/BentoBoxWorld/Bank/releases/tag/1.9.1)
+
 ## Translations
 
 {{ translations("Bank") }}

--- a/docs/addons/Border/index.md
+++ b/docs/addons/Border/index.md
@@ -36,6 +36,12 @@ Created and maintained by [tastybento](https://github.com/tastybento).
 **Permission**: `[gamemode].border.set-type`. Default: `true`.  
 **Example**: `/[player command] border type barrier`  
 
+### color {red|green|blue}
+**Command**: `/[player command] color {red | green | blue}`  
+**Description**: Sets the vanilla world border color for the player. Only applies when using the vanilla border type.  
+**Permission**: `[gamemode].color.red`, `[gamemode].color.green`, `[gamemode].color.blue` (or `[gamemode].color.*` for all). Default: `op`.  
+**Example**: `/[player command] color green`  
+
 !!! tip
     `[gamemode]` is a prefix that differs depending on the gamemode you are running.
     The prefix is the lowercased name of the gamemode, i.e. if you are using BSkyBlock, the prefix is `bskyblock`.
@@ -120,6 +126,34 @@ Set to `false` if you don't want **any** wall particles to be shown.
 ```
 show-particles: true
 ```
+
+### Show warps on map
+Controls whether the vanilla world border color feature is available. Colors for individual players are set with the `/[player_command] color` command. Requires a web map plugin (Dynmap or BlueMap) and the BentoBox map hook.
+
+```yml
+show-warps-on-map: true
+```
+
+## Placeholders
+
+| Placeholder | Description | Version |
+|---|---|---|
+| `%Border_color%` | The current border color for the player (`red`, `green`, or `blue`) | 4.8.0 |
+
+## Changelog
+
+??? note "What's new in v4.7.0 → v4.8.2"
+    **Released:** 2026-02-16 to 2026-04-04
+
+    - **Vanilla world border color selection.** Players using the vanilla border type can now choose their border color — red, green, or blue — via `/[player_command] color {red|green|blue}`.
+    - New `%Border_color%` placeholder returns the player's current border color.
+    - New permissions `[gamemode].color.red`, `[gamemode].color.green`, `[gamemode].color.blue` (or `[gamemode].color.*` for all colors). Default: op.
+    - Bug fix: border teleportation bypass when a player is outside all island spaces (4.7.0).
+    - Bug fix: vanilla world border not resetting when a player teleports between islands — was causing Bedrock/Geyser players to enter a restricted state (4.8.1).
+    - Bug fix: `%Border_color%` placeholder throwing null error in some configurations (4.8.1).
+    - Bug fix: border incorrectly activating in vanilla nether and end worlds (4.8.1).
+
+    [Release v4.7.0](https://github.com/BentoBoxWorld/Border/releases/tag/4.7.0) · [v4.8.0](https://github.com/BentoBoxWorld/Border/releases/tag/4.8.0) · [v4.8.1](https://github.com/BentoBoxWorld/Border/releases/tag/4.8.1) · [v4.8.2](https://github.com/BentoBoxWorld/Border/releases/tag/4.8.2)
 
 ## Translations
 

--- a/docs/addons/Challenges/index.md
+++ b/docs/addons/Challenges/index.md
@@ -274,6 +274,23 @@ You can find more information how BentoBox custom GUI's works here: [Custom GUI'
         completed-times-reached: "&2&l Completed all &7 [max] &2 times"
     ```
 
+## Changelog
+
+??? warning "What's new in v1.6.0 — locale regeneration required"
+    **Released:** 2026-04-13
+
+    - 🔡 **All locale files migrated to MiniMessage.** Every locale file has been converted from legacy `&` color codes to MiniMessage tags. Delete `BentoBox/locales/Challenges/` and restart to regenerate updated files.
+    - New challenge menu settings (contributed by @stuffyerface).
+    - Improved Web Library panel: language filter added, descriptions word-wrapped, loading indicator shown while catalog downloads, malformed catalog entries handled gracefully.
+    - Word-wrap applied to reward text in challenge and level lore for cleaner display.
+    - **New downloadable challenge libraries** available via the in-game Web Library:
+        - **Skyblock** — Modern Skyblock challenges with multiple progression paths (EN, ZH-CN, DE, ES, RU, FR)
+        - **AcidIsland** — Nautical challenge progression from Shipwrecked to Admiral (EN, ZH-CN, DE, ES, RU, FR)
+        - **Poseidon** — Default challenges for the Poseidon game mode (EN, ZH-CN, DE, ES, RU, FR)
+    - Requires BentoBox API 3.12.0+.
+
+    [Release v1.6.0](https://github.com/BentoBoxWorld/Challenges/releases/tag/1.6.0)
+
 ## Translations
 
 !!! info "Translations for challenges"

--- a/docs/addons/InvSwitcher/index.md
+++ b/docs/addons/InvSwitcher/index.md
@@ -23,7 +23,49 @@ The following are switched per-world:
 
 ## Config.yml
 
-There is no config.yml.
+InvSwitcher has a `config.yml` with two main sections.
+
+### Worlds
+
+Lists the gamemode worlds that InvSwitcher operates in. Nether and End worlds are included automatically.
+
+```yml
+worlds:
+- bskyblock_world
+- acidisland_world
+- oneblock_world
+# ... etc.
+```
+
+### Options
+
+Controls which player aspects are switched per-world and, optionally, per-island.
+
+```yml
+options:
+  inventory: true
+  health: true
+  food: true
+  advancements: true
+  gamemode: true       # game mode (Survival/Creative/etc.)
+  experience: true
+  ender-chest: true
+  statistics: true
+  # Per-island inventory switching (added in 1.17.0)
+  # The world-level option must also be true for the island option to take effect.
+  islands:
+    active: true       # Enable per-island switching overall
+    inventory: true    # Give players a different inventory on each island they own
+    health: false
+    food: false
+    advancements: false
+    gamemode: false
+    experience: false
+    ender-chest: true
+    statistics: false
+```
+
+Set `islands.active: true` to allow players who own more than one island to maintain separate inventories (and other aspects) per island, not just per gamemode world.
 
 ## Commands
 
@@ -40,6 +82,17 @@ This addon will give players a separate inventory, health, food level, advanceme
 
 **Please note:**
 - It is not limited to just BentoBox worlds. It applies to all worlds on the server (right now).
+
+## Changelog
+
+??? note "What's new in v1.17.0"
+    **Released:** 2026-03-31
+
+    - **Per-island inventory switching.** Players who own more than one island can now maintain separate inventories (and optionally health, food, experience, ender-chest, statistics) per island within the same gamemode. Enable with `options.islands.active: true` and configure each sub-option. The world-level option must also be `true` for its island counterpart to take effect.
+    - ⚙️ New `options.islands` section in `config.yml`.
+    - Bug fix: inventory was lost when returning to the original island.
+
+    [Release v1.17.0](https://github.com/BentoBoxWorld/InvSwitcher/releases/tag/1.17.0)
 
 ## Translations
 

--- a/docs/addons/Level/index.md
+++ b/docs/addons/Level/index.md
@@ -311,6 +311,8 @@ You can find more information how BentoBox custom GUI's works here: [Custom GUI'
     - `/[player_command] top`: access to the top panel. Requires `[gamemode].island.top` permission.
     - `/[player_command] level`: triggers level calculation for player. Requires `[gamemode].island.level` permission.
     - `/[player_command] value [material]`: allows to check block value. Requires `[gamemode].island.value` permission.
+    - `/[player_command] donate`: opens a chest-style GUI to donate blocks directly to your island's level. Donated points survive future level recalculations. Requires `[gamemode].island.level.donate` permission.
+    - `/[player_command] donate hand [amount]`: donates the item currently held in the player's hand (or the specified amount of it) directly to island level without opening the GUI. Requires `[gamemode].island.level.donate` permission.
 
 
 === "Admin commands"
@@ -337,6 +339,7 @@ You can find more information how BentoBox custom GUI's works here: [Custom GUI'
     - `[gamemode].island.level.details.spawners` - (default: `false`) - Allows player to see detailed list of spawners for island.
     - `[gamemode].island.level.details.underwater` - (default: `false`) - Allows player to see detailed list of underwater blocks for island.
     - `[gamemode].island.level.details.above-sea-level` - (default: `false`) - Allows player to see detailed list of above the sea level blocks for island.
+    - `[gamemode].island.level.donate` - (default: `true`) - Allows player to use the `/[player_command] donate` command.
 
 === "Admin permissions"
     - `[gamemode].admin.level` - (default: `op`) - Let the player use the `/[admin_command] level <player>` command.
@@ -392,6 +395,35 @@ You can find more information how BentoBox custom GUI's works here: [Custom GUI'
     ![template](https://user-images.githubusercontent.com/4407265/212773929-b51ae6b3-5df3-43ae-b35f-bc6fcb42d78f.png){: loading=lazy }
 
 
+
+## Changelog
+
+??? note "What's new in v2.23.0"
+    **Released:** 2026-02-21
+
+    - **Oraxen and Nexo furniture/custom block support.** Level can now count Oraxen furniture mechanics and Nexo custom blocks and furniture towards island level. These integrations are in beta — enable them if you have either plugin installed.
+    - New per-block placeholders: `[gamemode]_island_count_<block>` (count of a specific block on the island), `[gamemode]_island_value_<block>` (value of a block type), and `[gamemode]_island_limit_<block>` (configured block limit). Block keys use underscores, e.g. `_island_count_minecraft_stone`.
+
+    [Release v2.23.0](https://github.com/BentoBoxWorld/Level/releases/tag/2.23.0)
+
+??? warning "What's new in v2.24.0 — action required"
+    **Released:** 2026-04-12
+
+    - **Block donation system.** Players can now permanently donate blocks to their island's level via `/[player_command] donate` (GUI) or `/[player_command] donate hand [amount]` (quick donate from hand). Donated points are stored per-island and re-added after every level recalculation.
+    - New `ISLAND_BLOCK_DONATION` protection flag controls who can donate. Default is owner-only; can be extended down to Member rank.
+    - New **DONATED** tab in `detail_panel.yml` showing the island's donation history.
+    - New `island_members` variable available in the `level-cost` formula for handicapping larger teams.
+    - Admin level report now includes a donated-blocks breakdown.
+    - All locale files migrated to MiniMessage formatting.
+    - 🆕 Russian (`ru.yml`) locale added.
+    - Top ten ordering fix under concurrent writes.
+    - Block icons for hanging signs, vines, and cave vines now render correctly.
+
+    🔺 **Delete `plugins/BentoBox/addons/Level/panels/detail_panel.yml`** before restarting so the new DONATED tab template is generated. The file is not overwritten on upgrade.
+
+    🔡 **Regenerate locale files** if you have customisations — the old `&` color codes are no longer valid.
+
+    [Release v2.24.0](https://github.com/BentoBoxWorld/Level/releases/tag/2.24.0)
 
 ## Translations
 

--- a/docs/addons/Limits/index.md
+++ b/docs/addons/Limits/index.md
@@ -120,3 +120,27 @@ Some items cannot be limited (right now). The reasons are usually because there 
 * Ender dragon
 * Item frames
 * Paintings
+
+
+## Changelog
+
+??? warning "What's new in v1.28.0 — Java 21 required"
+    **Released:** 2026-04-01
+
+    - **Shulker duplication farms properly limited on Paper.** Uses Paper's `ShulkerDuplicateEvent` to enforce limits before duplication occurs, fixing a bypass where shulkers teleported outside the island before the limit check.
+    - **Copper chest limits can no longer be bypassed.** All copper chest variants (oxidized, waxed, scraped, golem-created) are now normalized to a single tracked material. Block state transitions are properly counted.
+    - **Invalid config entries handled gracefully.** Malformed namespaced keys, non-block materials, and uncountable materials (lava, water, air) in `blocklimits` config now produce clear warning messages instead of NPEs.
+    - 🔺 **Java 21 is now required** (previously Java 17). Ensure your server runs Java 21 before upgrading.
+    - Bumped Spigot target to 1.21.11.
+
+    [Release v1.28.0](https://github.com/BentoBoxWorld/Limits/releases/tag/1.28.0)
+
+??? note "What's new in v1.28.1"
+    **Released:** 2026-04-07
+
+    Hotfix for two regressions in 1.28.0:
+
+    - **Existing databases load again.** In 1.28.0 the `IslandBlockCount` map fields changed from `Map<Material, Integer>` to `Map<NamespacedKey, Integer>`, breaking reads of pre-1.28.0 JSON files. A backwards-compatible Gson `TypeAdapter` now reads legacy enum names, namespaced strings, and the complex array form. **No manual migration required** — old files load as-is.
+    - **Block names in the limits GUI are readable again.** Items were showing as `Minecraft:hopper` due to incorrect key formatting.
+
+    [Release v1.28.1](https://github.com/BentoBoxWorld/Limits/releases/tag/1.28.1)

--- a/docs/addons/Upgrades/index.md
+++ b/docs/addons/Upgrades/index.md
@@ -1,305 +1,102 @@
 # Upgrades
 
-**Upgrades** allows you to upgrade your island size, Entities/Blocks limits at the cost of money and island level.
+**Upgrades** gives players a progression curve by letting them purchase island upgrades — expanded protection range, higher block/entity limits, custom commands, spawner boosts, and crop growth boosts — using money, items, permissions, or island level.
 
-This addon was created to add a progression curve and a use of money for the island.
-
-Created and maintained by [Ikkino](https://github.com/Guillaume-Lebegue)
+Created and maintained by [tastybento](https://github.com/tastybento).
 
 {{ addon_description("Upgrades", true) }}
 
+!!! warning "Version 1.0.0 is a complete rewrite"
+    Upgrades 1.0.0 replaced the old config-file-based system with a fully **database-driven architecture**. Upgrade definitions, tiers, prices, and rewards are now stored in BentoBox's database and managed entirely in-game. **The old `config.yml` is no longer used** — remove it before installing 1.0.0 if you are upgrading from 0.x.
+
 ## Installation
 
-1. Place the Upgrades addon jar in the addons folder of the BentoBox plugin
-2. Restart the server
-3. The addon will create a data folder and inside the folder will be a config.yml
-4. Edit the config.yml how you want.
-5. Restart the server if you make a change
+1. Place the Upgrades addon jar in the addons folder of the BentoBox plugin.
+2. Restart the server.
+3. On first run, 8 example upgrades are seeded automatically so you can get started right away.
+4. Use `/[admin_command] upgrades` to customise or create upgrades in-game.
+
+## How It Works
+
+Upgrades, their tiers, prices, and rewards are stored in BentoBox's database (YAML, JSON, MySQL, MongoDB, etc.). There is no large config file to edit. All upgrade data is loaded, cached, and saved automatically by the addon.
+
+On first install the seeder creates 8 example upgrades. Once you delete an example upgrade it will not be re-seeded on the next restart. To re-trigger seeding, delete the `.seeded-gamemodes` marker file from the addon data folder.
 
 ## Commands
 
 !!! tip
-    `[player_command]` is a command that differs depending on the gamemode you are running.
-    The Gamemodes' `config.yml` file contains options that allows you to modify this value.
-    As an example, on BSkyBlock, the default `[player_command]` is `island`.
+    `[player_command]` and `[admin_command]` are commands that differ depending on the gamemode you are running.
 
-There is a user command to open a GUI with the upgrades.
+=== "Player commands"
+    - `/[player_command] upgrade`: opens the upgrade purchase panel.
 
-`/[Player command] upgrade`
+=== "Admin commands"
+    - `/[admin_command] upgrades`: opens the admin GUI to create, edit, and delete upgrades and their tiers.
 
-## Setup - Config.yml
+## Price Types
 
-The config.yml has the following sections:
+Each upgrade tier can require any combination of the following prices (all must be met to purchase):
 
-* range-upgrade
-* block-limits-upgrade
-* entity-limits-upgrade
-* command-upgrade
-* gamemodes
-* entity-icon
-* command-icon
+| Type | Description |
+|---|---|
+| **Money** | Vault economy cost |
+| **Items** | Specific items must be in the player's inventory |
+| **Permissions** | Player must hold a specific permission node |
+| **Island Level** | Minimum island level (requires Level addon) |
 
-!!! tip
-    All `upgrade`, `island-min-level` and `vault-cost` fields are mathematical expression. So:
+## Reward Types
 
-    * +,-,*,/,^,(,) can be used
-    * sqrt(), sin(), cos(), tan() can be used
-    * `[level]` is replaced by the actual level for this upgrade
-    * `[islandLevel]` is replaced by the island level from level addon **(Can be 0)**
-    * `[numberPlayer]` is replaced by the number of players in the team
+Each upgrade tier can grant any combination of the following rewards:
 
+| Type | Description |
+|---|---|
+| **Range** | Increases the island protection range |
+| **Block Limits** | Raises a block type's limit (requires Limits addon) |
+| **Entity Limits** | Raises an entity type's limit (requires Limits addon) |
+| **Entity Group Limits** | Raises an entity group's limit (requires Limits addon) |
+| **Commands** | Runs console or player commands on purchase |
+| **Spawner Boost** | Multiplies spawner spawn rates |
+| **Crop Growth Boost** | Multiplies crop growth speed |
 
-### General
+## Level Formula Variables
 
-One upgrade is divided by "tier" that can be named at will
+In price formulas, the following variables are available:
 
-Exemple:
-```yml
-tier1:
-  max-level: 5
-  upgrade: "5"
-  island-min-level: "2"
-  vault-cost: "[level]*100"
-  permission-level: 1
-```
-
-* `max-level` is the maximum level of this tier.
-* `upgrade` is how much is given at each level.
-* `island-min-level` is the minimum island level needed to buy this upgrade. It is given by [Level Addon](/addons/Level)
-* `vault-cost` is the cost to buy this upgrade **(>= 0)**
-* `permission-level` is the level of permission needed to buy this upgrade (cf. Permission)
-
-
-### Range Upgrade
-
-This upgrade increases the protection size of the island.
-
-The size increase is given in the `upgrade` field
-
-Exemple:
-```yaml
-range-upgrade:
-  tier1:
-    max-level: 5
-    upgrade: "5"
-    island-min-level: "2"
-    vault-cost: "[level]*100"
-  tier2:
-    max-level: 10
-    upgrade: "3"
-    island-min-level: "4"
-    vault-cost: "[level]*[numberPlayer]*200"
-```
-
-!!! warning "Max Range"
-    You should always check that, even at the maximum upgrade, the protection size never exceeds the size between island.
-
-### Block Limits Upgrade
-
-This upgrade increase the limits of blocks set in the [Limits Addon](/addons/Limits)
-
-The number to add to the limits is given by the `upgrade` field.
-
-Exemple:
-```yaml
-block-limits-upgrade:
-  HOPPER:
-    tier1:
-      max-level: 2
-      upgrade: "1"
-      island-min-level: "2"
-      vault-cost: "[level]*100"
-    tier2:
-      max-level: 5
-      upgrade: "1"
-      island-min-level: "4"
-      vault-cost: "([level]-2)*[numberPlayer]*700"
-      permission-level: 1
-```
-
-!!! tip "Blocks"
-    A list of blocks can be found [here](https://hub.spigotmc.org/javadocs/bukkit/org/bukkit/Material.html)
-
-
-### Entity Limits Upgrade
-
-This upgrade increase the limits of entities set in the [Limits Addon](/addons/Limits)
-
-All entities need to have a corresponding icon (CF: [entity-icon](#entity-icon))
-
-The number to add to the limits is given by the `upgrade` field.
-
-Exemple:
-```yaml
-entity-limits-upgrade:
-  CHICKEN:
-    tier1:
-      max-level: 2
-      upgrade: "1"
-      island-min-level: "2"
-      vault-cost: "[level]*100"
-    tier2:
-      max-level: 5
-      upgrade: "1"
-      island-min-level: "4"
-      vault-cost: "([level]-2)*[numberPlayer]*700"
-      permission-level: 3
-```
-
-!!! tip "Entities"
-    A list of entities can be found [here](https://hub.spigotmc.org/javadocs/spigot/org/bukkit/entity/EntityType.html)
-
-### Command Upgrade
-
-This upgrade runs given command on each upgrade
-
-All command upgrade needs to have a corresponding icon (CF: [command-icon](#command-icon))
-
-In the config:
-
-* The name of the section is the real name of the upgrade
-* The `name` field is only the display name. Not used in permission.
-* The `console` field specify if the command should be launched by the console or by the player
-* The `command` field is a list containing all the commands to run. They are launched in the list order
-
-!!! tip "Command Field"
-    In the command field:
-
-    * `[player]` is replaced by the name of the player who bought the upgrade
-    * `[level]` is replaced with the level of the upgrade
-
-Exemple:
-```yaml
-command-upgrade:
-  lambda-upgrade:
-    name: "Lambda upgrade"
-    tier1:
-      max-level: 1
-      island-min-level: "2"
-      vault-cost: "[level]*100"
-      console: true
-      command:
-        - "say [player] has upgrade his lambda to level [level]"
-    tier2:
-      max-level: 2
-      island-min-level: "2"
-      vault-cost: "[level]*200"
-      console: true
-      command: 
-        - "say [player] has upgrade his lambda to level [level]"
-        - "say [player] has reached the max level"
-```
-
-### Gamemode
-
-
-It is possible to set differences in upgrade between each gamemode.
-
-Exemple:
-```yaml
-gamemodes:
-  BSkyBlock:
-
-    range-upgrade:
-      tier3:
-        max-level: 15
-        upgrade: "5"
-        island-min-level: "6"
-        vault-cost: "[level]*[numberPlayer]*500"
-
-    block-limits-upgrade:
-      HOPPER:
-        tier1:
-          max-level: 2
-          upgrade: "1"
-          island-min-level: "2"
-          vault-cost: "[level]*200"
-```
-
-### Entity Icon
-
-This section is made to link entities to icons.
-
-Here the syntax:
-
-`ENTITY: MATERIAL`
-
-Exemple:
-```yaml
-entity-icon:
-  CHICKEN: CHICKEN_SPAWN_EGG
-```
-
-!!! tip "Entities"
-    A list of entities can be found [here](https://hub.spigotmc.org/javadocs/spigot/org/bukkit/entity/EntityType.html)
-
-!!! tip "Material"
-    A list of materials can be found [here](https://hub.spigotmc.org/javadocs/bukkit/org/bukkit/Material.html)
-
-### Command Icon
-
-This section is made to link command upgrade to icon.
-
-Here the syntax:
-
-`NAME: MATERIAL`
-
-`NAME` being the real name of the command upgrade (!= display name)
-
-Exemple:
-```yaml
-command-icon:
-  lambda-upgrade: GRASS
-```
-
-!!! tip "Material"
-    A list of materials can be found [here](https://hub.spigotmc.org/javadocs/bukkit/org/bukkit/Material.html)
+- `[level]` — the current upgrade level being purchased
+- `[islandLevel]` — the island's current level (from Level addon; may be 0)
+- `[numberPlayer]` — the number of players on the island team
 
 ## Permissions
 
-There can be permission for buying an upgrade.
+Permissions are granted automatically by the addon based on upgrade configuration. Check the [addon.yml](https://github.com/BentoBoxWorld/Upgrades/blob/develop/src/main/resources/addon.yml) for the current permission list.
 
-To do so, a `permission-level` superior to 0 should be added to the upgrade. To buy the upgrade, the player need to have a level superior or equal to this level. By default, a player has a level of 0 everywhere.
+## API
 
-Here is the permission:
+The `UpgradeAPI` class is exposed for other addons to query and modify upgrade data programmatically. See the JavaDocs linked from the addon description above.
 
-`[GAMEMODE].upgrades.[UPGRADE].[LEVEL]`
+## Changelog
 
-Where:
+??? warning "What's new in v1.0.0 — complete rewrite, action required"
+    **Released:** 2026-04-12
 
-* `[GAMEMODE]` is the name of the gamemode where this permission should be set
-* `[UPGRADE]` is the name of the upgrade (CF: [Name Upgrades](#name-upgrades))
-* `[LEVEL]` is the level to give to the player
+    - **Database-driven upgrade system.** All upgrades, tiers, prices, and rewards are now stored in BentoBox's database — no config file editing required.
+    - **New admin GUI.** `/[admin_command] upgrades` opens a full in-game admin interface to create and edit upgrades via GUI and chat-input.
+    - **New reward types:** Spawner Boost (multiplies spawner rates) and Crop Growth Boost (multiplies crop growth speed).
+    - **Templated player panel.** The player upgrade panel is now a BentoBox `TemplatedPanel` — fully customisable via `panels/upgrades_panel.yml`.
+    - **Full `UpgradeAPI`** for programmatic access from other addons.
+    - 8 example upgrades seeded automatically on first install.
+    - Compatibility fixes for Limits addon 1.28.
 
-Exemple:
+    🔺 **Not backwards-compatible with 0.x.** Remove your old `config.yml` and any existing upgrade data before installing. There is no automatic migration.
 
-`bskyblock.upgrades.range-upgrade.2`
+    [Release v1.0.0](https://github.com/BentoBoxWorld/Upgrades/releases/tag/1.0.0)
 
-!!! warning
-    Permission is in lowercase
+??? note "What's new in v1.0.1"
+    **Released:** 2026-04-12
 
-!!! tip
-    Because permission is created at runtime, it won't appear in a list of permissions
+    - **Seeder fix.** Example upgrades no longer regenerate on every restart after being deleted. The seeder now tracks which game modes have been seeded in a persistent `.seeded-gamemodes` marker file.
 
-### Name Upgrades
-
-**Range Upgrade**:
-
-`rangeupgrade` | Exemple: `bskyblock.upgrades.range-upgrade.1`
-
-**Block Limits Upgrade**:
-
-`limitsupgrade-[BLOCK]` | Exemple: `bskyblock.upgrades.limitsupgrade-hopper.8`
-
-**Entity Limits Upgrade**:
-
-`limitsupgrade-[ENTITY]` | Exemple: `bskyblock.upgrades.limitsupgrade-chicken-hopper.4`
-
-**Command Upgrade**:
-
-`command-[NAME]` | Exemple: `bskyblock.upgrades.command-lambda-upgrade.6`
-
-`NAME` being the real name of the command upgrade (!= display name)
+    [Release v1.0.1](https://github.com/BentoBoxWorld/Upgrades/releases/tag/1.0.1)
 
 ## Translations
 

--- a/docs/addons/Warps/index.md
+++ b/docs/addons/Warps/index.md
@@ -49,6 +49,13 @@ You can find the latest config file: [config.yml](https://github.com/BentoBoxWor
 
     Players must have the `welcomewarpsigns.warp` permission to use.
 
+??? question "What is show-warps-on-map?"
+    When set to `true`, warp sign locations are shown as markers on web map plugins (Dynmap, BlueMap).
+
+    Requires a compatible map plugin and the BentoBox map hook to be active. Each warp sign appears as a point marker with the text from the sign lines below `[Welcome]`.
+
+    Default: `true`
+
 ??? question "What is warp and warps?"
     The command `warp` requires `<player>` to which warp should happen, while `warps` opens menu that allows to choose a player.
 
@@ -160,6 +167,34 @@ You can find more information how BentoBox custom GUI's works here: [Custom GUI'
 
 ??? question "I have a bug, where should I report it?"
     Please add it to the list [here](https://github.com/BentoBoxWorld/Warps/issues).
+
+## Changelog
+
+??? note "What's new in v1.18.0"
+    **Released:** 2026-04-05
+
+    - **Web map support (Dynmap / BlueMap).** Warp signs now show as point markers on web maps when the `show-warps-on-map` option is enabled (default: true). Requires a BentoBox-compatible map plugin.
+    - ⚙️ New `show-warps-on-map` config option (see Configuration above).
+    - 🔡 Russian locale updated to MiniMessage format with full key coverage.
+    - Additional locale files added and updated to match BentoBox formatting.
+    - Requires BentoBox API 3.12.0+.
+
+    🔡 Delete `BentoBox/addons/Warps/locales/` to regenerate locale files with the new format.
+
+    [Release v1.18.0](https://github.com/BentoBoxWorld/Warps/releases/tag/1.18.0)
+
+??? warning "What's new in v1.19.0 — locale migration required"
+    **Released:** 2026-04-11
+
+    - **All locale files migrated to MiniMessage.** Every locale file has been converted from legacy `&` color codes to MiniMessage tags for consistency with BentoBox 3.14.
+    - Requires BentoBox API 3.14.0+.
+    - Warps now builds against Paper 1.21.11 exclusively (Spigot API dropped).
+
+    🔺 **BentoBox 3.14.0 required.** Ensure your BentoBox is updated before upgrading Warps.
+
+    🔡 **Regenerate locale files** — delete `BentoBox/locales/Warps/` and restart the server. Any `&` color codes in custom locale files will no longer render.
+
+    [Release v1.19.0](https://github.com/BentoBoxWorld/Warps/releases/tag/1.19.0)
 
 ## Translations
 

--- a/docs/gamemodes/AOneBlock/index.md
+++ b/docs/gamemodes/AOneBlock/index.md
@@ -633,3 +633,19 @@ AOneBlock has some custom events that are called only in AOneBlock. But BentoBox
             Block block = event.getBlock();
         }
         ```
+
+## Changelog
+
+??? warning "What's new in v1.23.0 — locale and config update required"
+    **Released:** 2026-04-11
+
+    - **Nexo custom block support.** AOneBlock now supports [Nexo](https://github.com/Nexo-MC/Nexo) custom blocks in phase definitions (alongside the existing ItemsAdder support). Define them with `type: nexo` and an `id` field in your phases config.
+    - **HEX / MiniMessage color support in action bar.** The `/ob actionbar` text now correctly renders HEX colors and full MiniMessage formatting.
+    - 🔡 Russian locale updated to MiniMessage format with grammar corrections.
+    - Several action bar locale and translation bug fixes.
+
+    🔺 **Nexo support is a new config option.** If you use Nexo, add Nexo-type block entries to your phase `.yml` files.
+
+    🔡 **Regenerate locale files** if you have customisations.
+
+    [Release v1.23.0](https://github.com/BentoBoxWorld/AOneBlock/releases/tag/1.23.0)

--- a/docs/gamemodes/AcidIsland/index.md
+++ b/docs/gamemodes/AcidIsland/index.md
@@ -34,6 +34,19 @@ Commands can be found [here](Commands).
 
 Placeholders can be found [here](Placeholders).
 
+## Changelog
+
+??? warning "What's new in v1.21.0 — BentoBox 3.14.0 required, locale migration"
+    **Released:** 2026-04-12
+
+    - **Cherry Grove Sanctuary starter island.** A new starter island blueprint themed around the Cherry Grove biome is included for Minecraft 1.21+ servers. To activate it, delete `BentoBox/addons/AcidIsland/blueprints/` so blueprints regenerate on the next startup.
+    - 🔺 **BentoBox API 3.14.0 is now required.** Update BentoBox before installing this release.
+    - 🔡 **All 24 locale files migrated from `&` codes to MiniMessage.** Delete `BentoBox/locales/AcidIsland/` and restart to regenerate. Any remaining `&` codes in custom files will render as plain text.
+    - Bug fix: NullPointerException in the EssentialsX god mode check when EssentialsX fails to load at startup.
+    - Several pre-existing locale bugs fixed during migration.
+
+    [Release v1.21.0](https://github.com/BentoBoxWorld/AcidIsland/releases/tag/1.21.0)
+
 ## Translations
 
 {{ translations("AcidIsland") }}


### PR DESCRIPTION
## Summary

Automated documentation update triggered by new releases detected since 2026-01-13. Covers 11 BentoBoxWorld repos (10 addons/gamemodes updated, BentoBox core tracker updated).

| Repo | Previous | New |
|---|---|---|
| AOneBlock | 1.22.0 | 1.23.0 |
| AcidIsland | 1.20.x | 1.21.0 |
| Bank | 1.9.0 | 1.9.1 |
| BentoBox | — | 3.14.1 (tracker updated; core docs unchanged) |
| Border | 4.6.0 | 4.8.2 |
| Challenges | 1.5.1 | 1.6.0 |
| InvSwitcher | 1.16.0 | 1.17.0 |
| Level | 2.22.0 | 2.24.0 |
| Limits | 1.27.1 | 1.28.1 |
| Upgrades | 0.x | 1.0.1 |
| Warps | 1.17.0 | 1.19.0 |

## Changes per repo

### Level (2.22.0 → 2.24.0)
- Added `/[player_command] donate` and `/[player_command] donate hand [amount]` commands
- Added `[gamemode].island.level.donate` permission
- Added `ISLAND_BLOCK_DONATION` to `data/flags.csv`
- Added Oraxen/Nexo support note and new per-block placeholder family to v2.23.0 changelog
- Added v2.24.0 changelog collapsible (warning level — action required)

### Border (4.6.0 → 4.8.2)
- Added `/[player_command] color {red|green|blue}` command
- Added `[gamemode].color.*` permissions
- Added `%Border_color%` placeholder to `data/placeholders.csv` and inline table
- Added changelog collapsible covering 4.7.0 → 4.8.2

### Warps (1.17.0 → 1.19.0)
- Added `show-warps-on-map` config option (Dynmap/BlueMap markers)
- Added v1.18.0 and v1.19.0 changelog collapsibles (v1.19.0 warning level — BentoBox 3.14 required)

### Upgrades (0.x → 1.0.1)
- **Complete rewrite** of the docs page to describe the new database-driven 1.0.0 architecture
- Documents admin GUI, new reward types (Spawner Boost, Crop Growth Boost), price types, UpgradeAPI
- Replaces all old config-file-based documentation

### InvSwitcher (1.16.0 → 1.17.0)
- Updated "There is no config.yml" → full config.yml documentation with worlds and options sections
- Added `options.islands` section (per-island inventory switching, new in 1.17.0)
- Added changelog collapsible for v1.17.0

### Bank (1.9.0 → 1.9.1)
- Added v1.9.1 changelog collapsible (top island name placeholders, interest fix)

### Challenges (1.5.1 → 1.6.0)
- Added v1.6.0 changelog collapsible (MiniMessage migration, new challenge libraries, menu settings)

### AOneBlock (1.22.0 → 1.23.0)
- Added v1.23.0 changelog collapsible (Nexo support, action bar MiniMessage)

### AcidIsland (1.20.x → 1.21.0)
- Added v1.21.0 changelog collapsible (Cherry Grove blueprint, MiniMessage migration, BentoBox 3.14 required)

### Limits (1.27.1 → 1.28.1)
- Added v1.28.0 changelog (shulker dupe fix, copper chest fix, Java 21 required)
- Added v1.28.1 changelog (database migration fix, GUI display fix)

## Data files

- `data/flags.csv` — added `ISLAND_BLOCK_DONATION` (Level)
- `data/placeholders.csv` — added `Border_color` (Border)
- `data/release-tracker.json` — created (new file); tracks last-checked timestamps for 32 repos

## Verification

- [x] `mkdocs build` completes successfully in 13 seconds
- [ ] `mkdocs build --strict` — fails on pre-existing issues only: GitHub API 403 rate-limit errors in `translations()` macro (no token set) and a known parse error in `Chat/cs.yml`. Neither is caused by this PR.

🤖 Generated with [Claude Code](https://claude.ai/claude-code) using the `update-docs` skill