### PR TITLE
chore: add project layout and dependency lookup to CLAUDE.md; fix translation percentage

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -63,3 +63,92 @@ The following pymdownx extensions are configured and usable in any doc page:
 `admonition`, `details`, `superfences`, `tabbed`, `tasklist`, `tilde`, `keys`, `progressbar`, `footnotes`, `attr_list`
 
 Admonition types commonly used: `note`, `warning`, `info`, `tip`
+
+## Dependency Source Lookup
+
+When you need to inspect source code for a dependency (e.g., BentoBox, addons):
+
+1. **Check local Maven repo first**: `~/.m2/repository/` — sources jars are named `*-sources.jar`
+2. **Check the workspace**: Look for sibling directories or Git submodules that may contain the dependency as a local project (e.g., `../bentoBox`, `../addon-*`)
+3. **Check Maven local cache for already-extracted sources** before downloading anything
+4. Only download a jar or fetch from the internet if the above steps yield nothing useful
+
+Prefer reading `.java` source files directly from a local Git clone over decompiling or extracting a jar.
+
+In general, the latest version of BentoBox should be targeted.
+
+## Project Layout
+
+Related projects are checked out as siblings under `~/git/`:
+
+**Core:**
+- `bentobox/` — core BentoBox framework
+
+**Game modes:**
+- `addon-acidisland/` — AcidIsland game mode
+- `addon-bskyblock/` — BSkyBlock game mode
+- `Boxed/` — Boxed game mode (expandable box area)
+- `CaveBlock/` — CaveBlock game mode
+- `OneBlock/` — AOneBlock game mode
+- `SkyGrid/` — SkyGrid game mode
+- `RaftMode/` — Raft survival game mode
+- `StrangerRealms/` — StrangerRealms game mode
+- `Brix/` — plot game mode
+- `parkour/` — Parkour game mode
+- `poseidon/` — Poseidon game mode
+- `gg/` — gg game mode
+
+**Addons:**
+- `addon-level/` — island level calculation
+- `addon-challenges/` — challenges system
+- `addon-welcomewarpsigns/` — warp signs
+- `addon-limits/` — block/entity limits
+- `addon-invSwitcher/` / `invSwitcher/` — inventory switcher
+- `addon-biomes/` / `Biomes/` — biomes management
+- `Bank/` — island bank
+- `Border/` — world border for islands
+- `Chat/` — island chat
+- `CheckMeOut/` — island submission/voting
+- `ControlPanel/` — game mode control panel
+- `Converter/` — ASkyBlock to BSkyBlock converter
+- `DimensionalTrees/` — dimension-specific trees
+- `discordwebhook/` — Discord integration
+- `Downloads/` — BentoBox downloads site
+- `DragonFights/` — per-island ender dragon fights
+- `ExtraMobs/` — additional mob spawning rules
+- `FarmersDance/` — twerking crop growth
+- `GravityFlux/` — gravity addon
+- `Greenhouses-addon/` — greenhouse biomes
+- `IslandFly/` — island flight permission
+- `IslandRankup/` — island rankup system
+- `Likes/` — island likes/dislikes
+- `Limits/` — block/entity limits
+- `lost-sheep/` — lost sheep adventure
+- `MagicCobblestoneGenerator/` — custom cobblestone generator
+- `PortalStart/` — portal-based island start
+- `pp/` — pp addon
+- `Regionerator/` — region management
+- `Residence/` — residence addon
+- `TopBlock/` — top ten for OneBlock
+- `TwerkingForTrees/` — twerking tree growth
+- `Upgrades/` — island upgrades (Vault)
+- `Visit/` — island visiting
+- `weblink/` — web link addon
+- `CrowdBound/` — CrowdBound addon
+
+**Data packs:**
+- `BoxedDataPack/` — advancement datapack for Boxed
+
+**Documentation & tools:**
+- `docs/` — main documentation site
+- `docs-chinese/` — Chinese documentation
+- `docs-french/` — French documentation
+- `BentoBoxWorld.github.io/` — GitHub Pages site
+- `website/` — website
+- `translation-tool/` — translation tool
+
+Check these for source before any network fetch.
+
+## Key Dependencies (source locations)
+
+- `world.bentobox:bentobox` → `~/git/bentobox/src/`

--- a/main.py
+++ b/main.py
@@ -74,13 +74,12 @@ def _flatten_yaml(data, prefix=""):
 
 
 def _is_translated(value, english_value) -> bool:
-    """A key counts as translated if it has a non-empty string value that
-    differs from the English source."""
+    """A key counts as translated if it has a non-empty value."""
     if value is None:
         return False
     if isinstance(value, str) and not value.strip():
         return False
-    return value != english_value
+    return True
 
 
 def _fetch_translation_status(repo: str, branch: str):


### PR DESCRIPTION
## Summary

- **CLAUDE.md**: Documents the full sibling-repo layout under `~/git/` and the dependency source-lookup strategy (local clone → Maven cache → GitHub API) so future sessions have complete context.
- **main.py** (`b4d4df0`, already on branch): Fixes `_is_translated()` — translation percentage was under-reporting (~79%) because keys with values identical to English (e.g. MiniMessage format strings) were counted as untranslated. A present, non-empty value now counts as translated regardless of whether it matches the English source.

## Test plan

- [ ] Confirm `mkdocs build` passes with no warnings
- [ ] Spot-check a fully-translated locale (e.g. `fr` or `zh`) — percentage should rise to expected level

🤖 Generated with [Claude Code](https://claude.ai/claude-code)