### PR TITLE
docs: update documentation for releases 2026-05-09

### DIFF
--- a/data/release-tracker.json
+++ b/data/release-tracker.json
@@ -1,5 +1,5 @@
 {
-  "last_run": "2026-04-26T12:00:00Z",
+  "last_run": "2026-05-09T22:22:00Z",
   "repos": {
     "BentoBox": {
       "last_checked": "2026-04-26T12:00:00Z",
@@ -14,8 +14,8 @@
       "category": "gamemode"
     },
     "AOneBlock": {
-      "last_checked": "2026-04-26T12:00:00Z",
-      "last_release": "1.24.0",
+      "last_checked": "2026-05-09T22:22:00Z",
+      "last_release": "1.25.0",
       "doc_path": "gamemodes/AOneBlock/index.md",
       "category": "gamemode"
     },
@@ -26,8 +26,8 @@
       "category": "gamemode"
     },
     "BSkyBlock": {
-      "last_checked": "2026-01-13T06:31:47Z",
-      "last_release": "",
+      "last_checked": "2026-05-09T22:22:00Z",
+      "last_release": "1.20.0",
       "doc_path": "gamemodes/BSkyBlock/index.md",
       "category": "gamemode"
     },
@@ -68,8 +68,8 @@
       "category": "addon"
     },
     "Biomes": {
-      "last_checked": "2026-01-13T06:31:47Z",
-      "last_release": "",
+      "last_checked": "2026-05-09T22:22:00Z",
+      "last_release": "2.3.0",
       "doc_path": "addons/Biomes/index.md",
       "category": "addon"
     },
@@ -128,8 +128,8 @@
       "category": "addon"
     },
     "InvSwitcher": {
-      "last_checked": "2026-04-13T06:53:32Z",
-      "last_release": "1.17.0",
+      "last_checked": "2026-05-09T22:22:00Z",
+      "last_release": "1.17.1",
       "doc_path": "addons/InvSwitcher/index.md",
       "category": "addon"
     },
@@ -140,8 +140,8 @@
       "category": "addon"
     },
     "Level": {
-      "last_checked": "2026-04-26T12:00:00Z",
-      "last_release": "2.25.0",
+      "last_checked": "2026-05-09T22:22:00Z",
+      "last_release": "2.26.0",
       "doc_path": "addons/Level/index.md",
       "category": "addon"
     },

--- a/docs/addons/Biomes/index.md
+++ b/docs/addons/Biomes/index.md
@@ -255,6 +255,30 @@ You can find more information how BentoBox custom GUI's works here: [Custom GUI'
 === "Admin permissions"
     - `[gamemode].admin.biomes` (default: `op`): player can use admin biomes command that opens GUI.
 
+## Changelog
+
+??? warning "What's new in v2.3.0 — requires BentoBox 3.14.0+ and Paper"
+    **Released:** 2026-05-05
+
+    - ⚙️ **Ocean biome preservation.** New `change-ocean-biomes` config option (default: `false`) prevents biome changes from overwriting ocean blocks (`OCEAN`, `WARM_OCEAN`, `DEEP_OCEAN`, etc.), keeping island shorelines and underwater areas intact. Set to `true` to restore the previous behaviour.
+    - **`COMMAND` panel action type.** Panel buttons can now run commands when clicked, both as a standalone button type and as an action on existing biome buttons alongside `CHANGE`/`BUY`/`ADVANCED_PANEL`. Useful for "Back to Island Panel" buttons or any custom integration.
+    - **Overhauled `biomesTemplate.yml`.** 44 biomes (up from ~29) with rebalanced costs, 9 new additions including Mangrove Swamp, Pale Garden (with The Creaking), and Bamboo Jungle, 3 starter bundles (Starter, Explorer, Nether & End), and `PER_USAGE` cost showcases.
+    - **Gamemode-aware unlock notifications.** Players in the correct gamemode world get the clickable "use it now" prompt; players elsewhere get a plain message naming the gamemode where the biome was unlocked, instead of a confused command in the wrong world.
+    - **Auto-import default biomes on first start.** When no biomes are configured for a gamemode, the addon now imports `biomesTemplate.yml` automatically — no more manual `import` step on fresh installs.
+    - **Biome queue cancellation on island delete/reset.** Queued and in-progress biome update tasks are cancelled on `IslandDeleteEvent` and `IslandResettedEvent`, with in-progress tasks stopping at the next chunk boundary via an `AtomicBoolean` flag.
+    - 🐛 Fixed floating-point display imprecision in admin GUI tooltips (e.g. `0.0299999999329447746` → `0.03`).
+    - 🐛 Decimal formatter pinned to `Locale.ROOT` so locales using comma decimals (e.g. German) render `0.5` as `0.5`, not `0,5`.
+    - 🐛 Biomes template items above the 99-block stack limit now split into valid stack sizes instead of failing to load.
+    - 🔡 All 23 locale files, panel YAMLs, and hardcoded Java strings migrated from legacy `&`-style color codes to MiniMessage. 14 new translations added (cs, de, hr, hu, id, it, ko, pt, pt-BR, ro, ru, tr, vi, zh-HK).
+
+    🔺 **Breaking:** This release requires **BentoBox 3.14.0+**, **Paper** (Spigot is no longer supported), and **Java 21**. The addon will not load against older versions.
+
+    🔡 **Locale note:** Customised locale files need updating — convert `&c`/`&l`/etc. to MiniMessage tags (`<red>`, `<bold>`), or delete your customisations to pick up the defaults.
+
+    ⚙️ **Config note:** Review `config.yml` for the new `change-ocean-biomes` option (default `false`).
+
+    [Release v2.3.0](https://github.com/BentoBoxWorld/Biomes/releases/tag/2.3.0)
+
 ## Translations
 
 {{ translations("Biomes") }}

--- a/docs/addons/InvSwitcher/index.md
+++ b/docs/addons/InvSwitcher/index.md
@@ -94,6 +94,13 @@ This addon will give players a separate inventory, health, food level, advanceme
 
     [Release v1.17.0](https://github.com/BentoBoxWorld/InvSwitcher/releases/tag/1.17.0)
 
+??? note "What's new in v1.17.1"
+    **Released:** 2026-05-09
+
+    - 🐛 **Fixed inventory cleared when teleporting from a BentoBox world to a non-BentoBox world.** When a player left a BentoBox game world (e.g. BSkyBlock) for a non-BentoBox world (e.g. the default overworld or a third-party plugin world), their "outside" inventory could be lost because each non-BentoBox world stored data under its own key. All non-BentoBox worlds now share a single storage key, so the player's inventory is always restored correctly. Includes automatic migration for data saved under the old per-world keys.
+
+    [Release v1.17.1](https://github.com/BentoBoxWorld/InvSwitcher/releases/tag/1.17.1)
+
 ## Translations
 
 {{ translations("InvSwitcher") }}

--- a/docs/addons/Level/index.md
+++ b/docs/addons/Level/index.md
@@ -445,6 +445,18 @@ You can find more information how BentoBox custom GUI's works here: [Custom GUI'
 
     [Release v2.25.0](https://github.com/BentoBoxWorld/Level/releases/tag/2.25.0)
 
+??? note "What's new in v2.26.0"
+    **Released:** 2026-05-04
+
+    - **Configurable donation panel.** The donate GUI is now fully template-driven via a new `panels/donation_panel.yml`, matching the value, detail, and top-ten panels. Admins can resize the panel from 1 to 6 rows, relocate the four named buttons (`INFO`, `CANCEL`, `PREVIEW`, `CONFIRM`), swap their icons, and add decorative items. The donation grid auto-fills every cell that isn't a border or named button.
+    - `force-shown: [1,2,3,4]` controls how many rows the panel uses (1–6 supported). The four required buttons are placed by `data.type`. If the template is missing or any required button is absent, the panel falls back to the previous hardcoded 4-row layout.
+    - 🐛 Decorative template items now actually render in the inventory; the custom `title:` on the donation panel is now respected; `force-shown` is parsed as a list (consistent with other panel YAMLs).
+    - No API breaks, no locale changes, no `config.yml` migrations.
+
+    ⚙️ **Donation panel layout.** A new `panels/donation_panel.yml` is shipped on first launch — leave it alone to keep the 2.25.0 layout, or edit it to customise.
+
+    [Release v2.26.0](https://github.com/BentoBoxWorld/Level/releases/tag/2.26.0)
+
 ## Translations
 
 {{ translations("Level") }}

--- a/docs/gamemodes/AOneBlock/index.md
+++ b/docs/gamemodes/AOneBlock/index.md
@@ -674,3 +674,16 @@ AOneBlock has some custom events that are called only in AOneBlock. But BentoBox
     🔡 **Regenerate locale files** to pick up new keys.
 
     [Release v1.24.0](https://github.com/BentoBoxWorld/AOneBlock/releases/tag/1.24.0)
+
+??? note "What's new in v1.25.0"
+    **Released:** 2026-05-03
+
+    - **Populated bee nest in Plenty.** The Plenty phase now spawns a `bee_nest` (3 bees inside, `honey_level=0`) at the same density as the existing honey items, closing the long-standing honey-farming gap.
+    - **Magic block client-side resync after mob rolls.** When the magic block rolled a mob, the cancelled break event left the block looking transparent client-side until the next chunk resync. The block state is now resent to the mining player immediately.
+    - 🐛 **CraftEngine startup-order fix.** `AOneBlock`'s `onEnable` runs before CraftEngine has populated its block registry, which previously caused a flood of false `Bad custom block` errors. The block parser now trusts an explicit `type: craftengine` declaration at config-load time and validates the ID at placement instead.
+    - 🐛 **Stricter CraftEngine block-ID validation at config load.** Blank IDs and IDs missing the `namespace:key` form are now rejected at config-load time instead of silently accepted and failing later.
+    - 🐛 **Configurable chest particles no longer crash on non-`DUST` types.** Particle types whose data type is non-`Void` (e.g. `ITEM`, `BLOCK`, `ENTITY_EFFECT`) used to throw `IllegalArgumentException`. They are now detected, logged as a warning, and skipped. `DUST` and void-data particles work unchanged.
+
+    🔺 If you want the new bee nest, copy the new entry into your `phases/8500_plenty.yml` (or delete the phases folder so it regenerates) — customised phase files are not overwritten on upgrade.
+
+    [Release v1.25.0](https://github.com/BentoBoxWorld/AOneBlock/releases/tag/1.25.0)

--- a/docs/gamemodes/BSkyBlock/index.md
+++ b/docs/gamemodes/BSkyBlock/index.md
@@ -38,6 +38,23 @@ Commands can be found [here](Commands).
 
 Placeholders can be found [here](Placeholders).
 
+## Changelog
+
+??? warning "What's new in v1.20.0 — requires BentoBox 3.13.0 and Paper 1.21.11"
+    **Released:** 2026-04-27
+
+    - 🐛 **Mob spawning fixed.** The chunk generator was not overriding `shouldGenerateMobs()`, which silently suppressed vanilla mob spawning in all BSkyBlock-generated worlds. Mobs now spawn correctly again.
+    - 🐛 **Water animals (fish, squid) spawning fixed.** Restores natural fish and squid spawning, broken since the 1.21 platform migration. Fixes [BentoBox #2593](https://github.com/BentoBoxWorld/BentoBox/issues/2593).
+    - ⚡ **Modern chunk generation.** The world generator has been migrated from the deprecated `generateChunkData()` + `BiomeGrid` approach to Paper's current `generateNoise()` + `BiomeProvider` API.
+    - 🔡 All 17 locale sign files migrated from legacy `&c` color codes to MiniMessage format.
+    - Build modernised: JDK 21, JUnit 5 + MockBukkit test stack.
+
+    🔺 **Requires BentoBox 3.13.0 or newer and Paper 1.21.11.** Earlier versions of BentoBox will not load this addon.
+
+    🔡 **Locale note:** Sign text now uses MiniMessage tags (e.g. `<red>…</red>` instead of `&c`). Customised locale files need updating.
+
+    [Release v1.20.0](https://github.com/BentoBoxWorld/BSkyBlock/releases/tag/1.20.0)
+
 ## Translations
 
 {{ translations("BSkyBlock") }}


### PR DESCRIPTION
## Summary

Documentation updates triggered by new releases detected since the 2026-04-26 run.

| Repo | Previous | New |
|---|---|---|
| AOneBlock | 1.24.0 | 1.25.0 |
| BSkyBlock | (untracked) | 1.20.0 |
| Biomes | (untracked) | 2.3.0 |
| InvSwitcher | 1.17.0 | 1.17.1 |
| Level | 2.25.0 | 2.26.0 |

## Changes per repo

### AOneBlock 1.24.0 → 1.25.0
- New "What's new in v1.25.0" entry covering the populated bee nest in Plenty, magic-block client-side resync, and the CraftEngine startup-order/validation/particle fixes.

### BSkyBlock → 1.20.0
- Added a new `## Changelog` section to `gamemodes/BSkyBlock/index.md` (the page didn't have one).
- Documented the mob-spawning and water-animal fixes, the `BiomeProvider` chunk-generator migration, the locale MiniMessage migration, and the new BentoBox 3.13.0 / Paper 1.21.11 / Java 21 requirements.

### Biomes → 2.3.0
- New "What's new in v2.3.0" entry flagged as a **breaking change** (requires BentoBox 3.14.0+, Paper, Java 21).
- Documents the new `change-ocean-biomes` config option (default `false`), the `COMMAND` panel action type, the overhauled `biomesTemplate.yml`, gamemode-aware unlock notifications, auto-import on first start, biome-queue cancellation on island delete/reset, and the MiniMessage formatting migration with 14 new translations.

### InvSwitcher 1.17.0 → 1.17.1
- New "What's new in v1.17.1" entry covering the cross-world inventory-loss fix and automatic per-world key migration.

### Level 2.25.0 → 2.26.0
- New "What's new in v2.26.0" entry covering the configurable donation panel (new `panels/donation_panel.yml`, 1–6 row layout, named-button placement, decorative slot reservation, fallback to the previous hardcoded layout).

## Verification

- [x] `mkdocs build --strict` passes with zero warnings (with `GITHUB_TOKEN` set so the `translations()` macro doesn't hit the unauthenticated 60/hr rate limit; the same warning would fire on every run without a token and is unrelated to this change).
- [x] Tracker `data/release-tracker.json` updated to record the new `last_checked` and `last_release` for the five repos above.

🤖 Generated with [Claude Code](https://claude.ai/claude-code) using the `update-docs` skill