### PR TITLE
docs: update documentation for releases 2026-05-10

### DIFF
--- a/data/release-tracker.json
+++ b/data/release-tracker.json
@@ -1,9 +1,9 @@
 {
-  "last_run": "2026-05-09T22:22:00Z",
+  "last_run": "2026-05-10T19:08:23Z",
   "repos": {
     "BentoBox": {
-      "last_checked": "2026-04-26T12:00:00Z",
-      "last_release": "3.15.0",
+      "last_checked": "2026-05-10T19:08:23Z",
+      "last_release": "3.16.0",
       "doc_path": "BentoBox/",
       "category": "core"
     },

--- a/docs/BentoBox/About/Teams.md
+++ b/docs/BentoBox/About/Teams.md
@@ -194,3 +194,51 @@ Coop players hold their rank until the player who invited them logs out, or unti
 ### Untrusting or uncooping players
 Island owners, or players with a high enough rank, can issue the `team untrust` or `team uncoop` commands to remove players from the island with these ranks. The removed player reverts to Visitor status.
 
+## Disabling Teams Per-World
+
+As of BentoBox 3.16.0, a game mode can opt out of the team subsystem on a per-world basis via the `WorldSettings#isTeamsDisabled()` API (default `false`). When enabled, the action commands that add, remove or reorganise team members refuse to run with the locale message `commands.island.team.errors.teams-disabled`.
+
+**Blocked when teams are disabled:**
+
+- `/island team invite` and `team invite accept` (TEAM invitations only — COOP and TRUST invitations remain accepted)
+- `/island team kick`, `team leave`, `team promote`, `team demote`, `team setowner`
+- `/[admin] team add`
+
+**Still available:**
+
+- Read-only player commands: `/island team` panel, `team info`, `team invites`, `team invite reject`
+- Trust and coop relationships: `trust`, `coop`, `untrust`, `uncoop` — these are the supported alternative when teams are off
+- Admin commands that operate on existing teams: `kick`, `disband`, `disbandall`, `setowner`, `fix`, `maxsize`
+
+After flipping `isTeamsDisabled` on for a world that already has teams, run `/[admin] team disbandall` once to clean up pre-existing teams. This admin command strips every member and sub-owner from every island in the current world in one confirmable pass. Trusted and coop players are intentionally untouched.
+
+??? note "What's new in v3.16.0"
+    **Released:** 2026-05-10
+
+    See the full notes: [Release 3.16.0](https://github.com/BentoBoxWorld/BentoBox/releases/tag/3.16.0)
+
+    **Team handling**
+
+    - New `WorldSettings#isTeamsDisabled()` API (default `false`) lets a game mode opt out of the team subsystem on a per-world basis.
+    - New admin command `/[admin] team disbandall` strips every member and sub-owner from every island in the current world in one confirmable pass.
+    - `/[admin] team kick` now requires explicit `x,y,z` coordinates when the target is on multiple team islands, and refuses to kick island owners (pointing the admin to `setowner` or `disband` instead).
+    - Setowner cap is now enforced on both `/island team setowner` and `/[admin] team setowner` — transfers refuse when the recipient is at their concurrent-islands cap.
+
+    **Bug fixes**
+
+    - `ISLAND_RESPAWN` no longer drops players at world spawn (0,0) when their home block is missing — it now walks a fallback chain ending in `SafeSpotTeleport`.
+    - `OFFLINE_GROWTH` now blocks every spreading plant (vines, weeping/twisting vines, etc.) and trees/mushrooms growing from saplings — not just kelp and bamboo.
+    - Dynmap area/polygon markers now use the world's full min/max height instead of always rendering at y=64.
+
+    **API additions**
+
+    - `CraftEngineHook.getItemStack(String id)` and `CraftEngineHook.getItemId(ItemStack item)` let addons render and recognise CraftEngine custom items without depending on CraftEngine directly.
+
+    **Locale**
+
+    - New keys: `commands.admin.team.disbandall.{description,confirmation,success}`, `commands.island.team.errors.teams-disabled`, `commands.admin.team.setowner.errors.at-max`.
+    - Updated `commands.admin.team.kick.cannot-kick-owner` message that points admins to `setowner`/`disband`.
+    - Removed the dead `commands.admin.team.kick.success-all` key.
+    - All 22 bundled translations are in sync.
+
+    **Compatibility:** Paper Minecraft 1.21.5 – 26.1.2, Java 21+.

--- a/docs/BentoBox/ConcurrentIslands.md
+++ b/docs/BentoBox/ConcurrentIslands.md
@@ -30,9 +30,11 @@ Players can set the default location of their island by running the `sethome` co
 
 ### Island transfer
 
-Island ownership can be transfered to other players on the team using the `setowner` command. Ownership cannot be transfered if the owner already has the maximum number of concurrent islands allowed.
+Island ownership can be transferred to other players on the team using the `setowner` command. Ownership cannot be transferred if the recipient is already at their maximum number of concurrent islands.
 
-*NEW:* When a player transfers ownership then now automatically leave the team.
+As of BentoBox 3.16.0, this cap is enforced on both `/island team setowner` and `/[admin] team setowner`. Earlier versions only emitted a warning after an admin transfer (and the player command had no check at all), which allowed players to be pushed over their `concurrent-islands` limit. To allow more islands for the recipient, raise their `[gamemode].island.number.<n>` permission first.
+
+*NEW:* When a player transfers ownership they now automatically leave the team.
 
 ### Teams
 


### PR DESCRIPTION
## Summary

Documentation updates triggered by new releases detected since 2026-05-09:

| Repo | Previous | New |
|---|---|---|
| BentoBox | 3.15.0 | 3.16.0 |

No new releases were found in any other tracked repo since the last run.

## Changes per repo

### BentoBox (3.15.0 → 3.16.0)

**`docs/BentoBox/About/Teams.md`**
- New section "Disabling Teams Per-World" covering the new `WorldSettings#isTeamsDisabled()` opt-in API: lists which player commands and admin commands are blocked vs. still available, and the recommended one-time `/[admin] team disbandall` after flipping the setting on.
- Added a "What's new in v3.16.0" collapsible summarising:
  - Per-world team disable + `disbandall` admin command
  - Admin `team kick` now requires `x,y,z` for multi-island targets and refuses owners
  - Setowner cap enforcement on both player and admin paths
  - Bug fixes: `ISLAND_RESPAWN` safe fallback, `OFFLINE_GROWTH` for vines/trees, Dynmap marker Y range
  - `CraftEngineHook.getItemStack(id)` and `getItemId(item)` helpers
  - Locale key changes (added/removed/updated keys, all 22 translations in sync)

**`docs/BentoBox/ConcurrentIslands.md`**
- Clarified that the setowner cap is now enforced on both `/island team setowner` and `/[admin] team setowner` as of 3.16.0, closing the prior bypass. Notes how to raise the recipient's `[gamemode].island.number.<n>` permission if more islands are intended.
- Fixed a couple of typos in the surrounding paragraph while there.

**`data/release-tracker.json`**
- BentoBox `last_release` bumped from `3.15.0` to `3.16.0`; `last_run` updated.

## Verification

- [x] `mkdocs build --strict` passes with zero warnings (with `GITHUB_TOKEN` set so the `translations()` macro can fetch locale listings).

🤖 Generated with [Claude Code](https://claude.ai/claude-code) using the `update-docs` skill