### PR TITLE
docs: update documentation for releases 2026-05-17

### DIFF
--- a/data/release-tracker.json
+++ b/data/release-tracker.json
@@ -1,9 +1,9 @@
 {
-  "last_run": "2026-05-10T19:08:23Z",
+  "last_run": "2026-05-17T06:34:07Z",
   "repos": {
     "BentoBox": {
-      "last_checked": "2026-05-10T19:08:23Z",
-      "last_release": "3.16.0",
+      "last_checked": "2026-05-17T06:34:07Z",
+      "last_release": "3.16.1",
       "doc_path": "BentoBox/",
       "category": "core"
     },
@@ -56,8 +56,8 @@
       "category": "gamemode"
     },
     "StrangerRealms": {
-      "last_checked": "2026-01-13T06:31:47Z",
-      "last_release": "",
+      "last_checked": "2026-05-17T06:34:07Z",
+      "last_release": "1.0.4",
       "doc_path": "gamemodes/StrangerRealms/index.md",
       "category": "gamemode"
     },
@@ -140,8 +140,8 @@
       "category": "addon"
     },
     "Level": {
-      "last_checked": "2026-05-09T22:22:00Z",
-      "last_release": "2.26.0",
+      "last_checked": "2026-05-17T06:34:07Z",
+      "last_release": "2.27.0",
       "doc_path": "addons/Level/index.md",
       "category": "addon"
     },
@@ -164,7 +164,7 @@
       "category": "addon"
     },
     "TopBlock": {
-      "last_checked": "2026-04-26T12:00:00Z",
+      "last_checked": "2026-05-17T06:34:07Z",
       "last_release": "2.0.0",
       "doc_path": "addons/TopBlock/index.md",
       "category": "addon"

--- a/docs/BentoBox/About/IslandManagement.md
+++ b/docs/BentoBox/About/IslandManagement.md
@@ -43,7 +43,9 @@ Admins can delete a player's island with:
 /[admin_command] delete <player>
 ```
 
-This removes the island from the database and queues the area for cleanup. The player will be able to create a new island afterwards.
+This removes the island from the database and marks the area for cleanup. The player can create a new island immediately afterwards.
+
+As of BentoBox 3.16.1, the actual region files are reaped on the next housekeeping sweep (default: 24 h) rather than on demand. If the island shares a region file with other live islands, the deleted area stays in place until that region is clear. To force immediate cleanup, run `/bbox admin purge deleted` after the delete — it will only remove blocks if the region file no longer hosts any live island. For surgical block removal in a shared region, use WorldEdit or remove the blocks manually.
 
 ## Inactive Island Cleanup
 
@@ -117,3 +119,14 @@ Players can check their own island info with `/island info`. Admins can check an
 /[admin_command] info <player>
 ```
 This shows the island's location, owner, team members, and current protection range.
+
+??? note "What's new in v3.16.1"
+    **Released:** 2026-05-17
+
+    Targeted patch for `/bbox admin delete`. See the full notes: [Release 3.16.1](https://github.com/BentoBoxWorld/BentoBox/releases/tag/3.16.1)
+
+    - 🔺 `/bbox admin delete` now actually deletes the island. The reap happens on the next housekeeping sweep (default: 24 h) rather than instantly; if the region file still hosts live islands, the deleted island remains in the deleted state until the region is clear. Use WorldEdit or remove blocks manually if you need immediate cleanup of a shared region.
+    - 🔺 Seed worlds (`<world>/bentobox`) are no longer created. The seed-world plumbing (`createSeedWorlds`, `removeSeedWorlds`, the in-memory copies, the on-disk folders) is gone. Any stale `<world>/bentobox` folders left over from earlier versions are safe to delete manually.
+    - 🔺 API: `GameModeAddon#isUsesNewChunkGeneration()` is deprecated for removal. Existing overrides keep working (the value is ignored) but emit a deprecation warning — remove the override at your convenience.
+
+    **Compatibility:** Paper Minecraft 1.21.5 – 26.1.2, Java 21+.

--- a/docs/addons/Level/index.md
+++ b/docs/addons/Level/index.md
@@ -66,6 +66,17 @@ This section defines a number of overall settings for the add-on.
 
     Default: `true`
 
+??? note "donations-only"
+    If true, the island block scan is skipped entirely and the island level is computed only from blocks donated via `/island donate`. This removes the per-recalculation CPU cost of scanning the island.
+
+    `/island level`, `/island top`, `/island value`, and `/island donate` continue to work. `/island detail` is not registered in this mode, since there are no scanned blocks to break down. The top-ten panel's viewer button no longer shows "Click to view" or opens the detail panel.
+
+    The zero-island scan that runs on island creation/reset still runs when `zero-new-island-levels: true`, so the starter-island handicap is recorded into `initialCount` and applied correctly if an admin later turns donations-only off. While donations-only is on, the stored `initialCount` is ignored at `/island level` time, so flipping the mode on for a server with existing islands does not push players to wildly negative levels.
+
+    Requires BentoBox 3.16.0 or later.
+
+    Default: `false`
+
 ??? note "login"
     Allows to set that island level is calculated on player login.
 
@@ -181,13 +192,15 @@ This section defines values for blocks and limits for them.
 
     Format: `MATERIAL: NUMBER`
 
-    CraftEngine custom blocks are also supported (requires BentoBox 3.15.0+). Use their namespaced ID as the key:
+    Custom blocks from Oraxen, Nexo, ItemsAdder, and CraftEngine are also supported. Use their namespaced ID as the key:
 
     ```yaml
     blocks:
       mynamespace:my_block: 50
       mynamespace:custom_ore: 3
     ```
+
+    As of Level 2.27.0, custom blocks are no longer filtered out of `/level value`, render with their real texture/model data and display name in `/level detail` and the value panel, and can be donated via `/island donate hand`, `/island donate inv`, and the donation panel. CraftEngine items are resolved via BentoBox 3.16.0's `CraftEngineHook.getItemId` / `getItemStack` helpers — earlier BentoBox versions will refuse to load Level 2.27.0+.
 
 ??? note "worlds"
     List any blocks that have a different value in a specific world. 
@@ -321,6 +334,7 @@ You can find more information how BentoBox custom GUI's works here: [Custom GUI'
     - `/[player_command] value [material]`: allows to check block value. Requires `[gamemode].island.value` permission.
     - `/[player_command] donate`: opens a chest-style GUI to donate blocks directly to your island's level. Donated points survive future level recalculations. Requires `[gamemode].island.level.donate` permission.
     - `/[player_command] donate hand [amount]`: donates the item currently held in the player's hand (or the specified amount of it) directly to island level without opening the GUI. Requires `[gamemode].island.level.donate` permission.
+    - `/[player_command] donate inv`: lists every donatable block in the player's inventory with per-material values and a running total, then on confirm donates them all and runs a level recalc. Items with no configured value and non-blocks stay in the inventory. Requires `[gamemode].island.level.donate` permission.
 
 
 === "Admin commands"
@@ -456,6 +470,21 @@ You can find more information how BentoBox custom GUI's works here: [Custom GUI'
     ⚙️ **Donation panel layout.** A new `panels/donation_panel.yml` is shipped on first launch — leave it alone to keep the 2.25.0 layout, or edit it to customise.
 
     [Release v2.26.0](https://github.com/BentoBoxWorld/Level/releases/tag/2.26.0)
+
+??? warning "What's new in v2.27.0 — action required"
+    **Released:** 2026-05-13
+
+    🔺 **Requires BentoBox 3.16.0 or later.** This release bumps the `api-version` in `addon.yml` to `3.16.0` and depends on the new `CraftEngineHook.getItemId` / `getItemStack` helpers. Older BentoBox versions will refuse to load the addon.
+
+    - ⚙️ **Donations-only mode.** New `donations-only` option in `config.yml` (default `false`). When `true`, the per-recalculation chunk scan is skipped entirely and the island level is computed from donated points alone using the configured `level-calc` formula. `/island detail` is not registered in this mode and the top-ten viewer button stops opening the detail panel. The stored `initialCount` is ignored at `/island level` time, so flipping the mode on for a server with existing islands does not push players to wildly negative levels.
+    - 💎 **`/island donate inv` — donate everything from inventory.** New confirmable `inv` subcommand: lists every donatable block in the player's inventory with per-material values and a running total, then on confirm donates them all and runs a level recalc. Items with no configured value and non-blocks stay in the inventory. Tab-complete now suggests `hand` / `inv` for the first arg, and the held-item count after `hand`.
+    - 🧱 **Custom block support across value, detail, and donate menus.** Oraxen, Nexo, ItemsAdder, and CraftEngine custom blocks are no longer filtered out of `/level value` or rendered as nameless PAPER icons in `/level detail`. The value panel and details panel look up the real custom-block `ItemStack` from each plugin's registry, so the configured texture/model data and display name are preserved. `/island value hand` on a held custom item now reports the configured value and display name. Donation paths (`/island donate hand`, `/island donate inv`, the donation panel) accept custom-block items and record donations under the custom ID.
+    - 🐛 **Negative progression fix.** Non-linear `level-calc` formulas (e.g. `3 * sqrt(blocks / level_cost)`) no longer dip below zero between levels. Thanks @msmith-codes!
+    - ⚡ **Performance.** `tidyUp()` no longer walks up to 10M points linearly on the primary thread when computing point boundaries — the forward and backward scans now use binary search (~23 iterations instead of millions).
+
+    🔡 **Locales updated.** All 18 shipped locales gained new `island.donate.inv.*` keys (`keyword`, `confirm-header`, `confirm-line`, `confirm-total`). If you have customised locale files in `plugins/BentoBox/addons/Level/locales/`, copy the new `donate.inv` block into them or the new `/island donate inv` flow will show raw keys.
+
+    [Release v2.27.0](https://github.com/BentoBoxWorld/Level/releases/tag/2.27.0)
 
 ## Translations
 

--- a/docs/gamemodes/StrangerRealms/index.md
+++ b/docs/gamemodes/StrangerRealms/index.md
@@ -65,6 +65,17 @@ The core game mechanics and claim features are highly configurable via the Bento
 
 Permissions can be found [here](Permissions).
 
+??? note "What's new in v1.0.4"
+    **Released:** 2026-05-16
+
+    Bug-fix release for the dynamic world border. See the full notes: [Release 1.0.4](https://github.com/BentoBoxWorld/StrangerRealms/releases/tag/1.0.4)
+
+    - Fixed a sporadic `NullPointerException` in `getBorderSize()` on the first dynamic-border shrink (e.g., when player count dropped) that spammed the console and stalled the border until the next restart. The cancel path now uses the null-guarded `cancelBorderTask()` helper.
+    - The startup warning about not using the BentoBox `Border` addon previously referenced "the Crowdbound world" by mistake; it now reads `StrangerRealms has its own Border, so do not use Border addon.`
+    - Built and tested against Paper API 1.21.11 to keep pace with MockBukkit's tracking branch.
+
+    **Compatibility:** BentoBox API 3.9.0+, Minecraft 1.21.10+, Java 21.
+
 ## Translations
 
 {{ translations("StrangerRealms") }}


### PR DESCRIPTION
## Summary

Documentation updates triggered by new releases detected since the last run (2026-05-10):

| Repo | Previous | New |
|---|---|---|
| BentoBox | 3.16.0 | 3.16.1 |
| StrangerRealms | 1.0.3 | 1.0.4 |
| Level | 2.26.0 | 2.27.0 |
| TopBlock | 2.0.0 | 2.0.0 (already documented; tracker refreshed) |

## Changes per repo

### BentoBox (3.16.0 → 3.16.1)
- Updated `Island Deletion (Admin)` section in `BentoBox/About/IslandManagement.md` to describe the new soft-delete behavior: the actual region files are reaped on the next housekeeping sweep, and `/bbox admin purge deleted` is the manual cleanup path.
- Added a `What's new in v3.16.1` admonition covering the admin delete fix, the removal of `<world>/bentobox` seed worlds, and the deprecation of `GameModeAddon#isUsesNewChunkGeneration()`.

### StrangerRealms (1.0.3 → 1.0.4)
- Added a `What's new in v1.0.4` admonition for the dynamic-world-border NPE fix, the corrected "Crowdbound" warning message, and the Paper 1.21.11 build target.

### Level (2.26.0 → 2.27.0)
- Added new `donations-only` config option block to the Configuration section.
- Documented the new `/island donate inv` player command.
- Updated the `blocks` config-block note to reflect first-class custom block support (Oraxen, Nexo, ItemsAdder, CraftEngine) across `/level value`, `/level detail`, and the donation menus, and called out the BentoBox 3.16.0+ requirement.
- Added `What's new in v2.27.0 — action required` warning admonition.

### TopBlock 2.0.0
- The release was published 3 hours after the previous tracker run, so it surfaced again, but the doc page already covers it (intopten permission, v2.0.0 changelog entry, etc.). No content changes — only the tracker timestamp moves forward.

## Verification

- [x] `mkdocs build --strict` passes with `GITHUB_TOKEN` set (exit 0).
- [x] No new pages created — no nav changes needed.
- [x] No CSV row additions needed (no new flags, placeholders, or commands required schema changes).

🤖 Generated with [Claude Code](https://claude.ai/claude-code) using the `update-docs` skill