### PR TITLE
docs: update documentation for releases 2026-05-23

### DIFF
--- a/data/release-tracker.json
+++ b/data/release-tracker.json
@@ -1,194 +1,194 @@
 {
-  "last_run": "2026-05-17T06:34:07Z",
+  "last_run": "2026-05-23T00:37:17Z",
   "repos": {
     "BentoBox": {
-      "last_checked": "2026-05-17T06:34:07Z",
-      "last_release": "3.16.1",
+      "last_checked": "2026-05-23T00:37:17Z",
+      "last_release": "3.16.2",
       "doc_path": "BentoBox/",
       "category": "core"
     },
     "AcidIsland": {
-      "last_checked": "2026-04-15T12:15:40Z",
+      "last_checked": "2026-05-23T00:37:17Z",
       "last_release": "1.22.0",
       "doc_path": "gamemodes/AcidIsland/index.md",
       "category": "gamemode"
     },
     "AOneBlock": {
-      "last_checked": "2026-05-09T22:22:00Z",
+      "last_checked": "2026-05-23T00:37:17Z",
       "last_release": "1.25.0",
       "doc_path": "gamemodes/AOneBlock/index.md",
       "category": "gamemode"
     },
     "Boxed": {
-      "last_checked": "2026-01-13T06:31:47Z",
+      "last_checked": "2026-05-23T00:37:17Z",
       "last_release": "",
       "doc_path": "gamemodes/Boxed/index.md",
       "category": "gamemode"
     },
     "BSkyBlock": {
-      "last_checked": "2026-05-09T22:22:00Z",
+      "last_checked": "2026-05-23T00:37:17Z",
       "last_release": "1.20.0",
       "doc_path": "gamemodes/BSkyBlock/index.md",
       "category": "gamemode"
     },
     "CaveBlock": {
-      "last_checked": "2026-01-13T06:31:47Z",
+      "last_checked": "2026-05-23T00:37:17Z",
       "last_release": "",
       "doc_path": "gamemodes/CaveBlock/index.md",
       "category": "gamemode"
     },
     "poseidon": {
-      "last_checked": "2026-01-13T06:31:47Z",
+      "last_checked": "2026-05-23T00:37:17Z",
       "last_release": "",
       "doc_path": "gamemodes/Poseidon/index.md",
       "category": "gamemode"
     },
     "RaftMode": {
-      "last_checked": "2026-01-13T06:31:47Z",
+      "last_checked": "2026-05-23T00:37:17Z",
       "last_release": "",
       "doc_path": "gamemodes/RaftMode/index.md",
       "category": "gamemode"
     },
     "SkyGrid": {
-      "last_checked": "2026-01-13T06:31:47Z",
+      "last_checked": "2026-05-23T00:37:17Z",
       "last_release": "",
       "doc_path": "gamemodes/SkyGrid/index.md",
       "category": "gamemode"
     },
     "StrangerRealms": {
-      "last_checked": "2026-05-17T06:34:07Z",
-      "last_release": "1.0.4",
+      "last_checked": "2026-05-23T00:37:17Z",
+      "last_release": "1.0.5",
       "doc_path": "gamemodes/StrangerRealms/index.md",
       "category": "gamemode"
     },
     "Bank": {
-      "last_checked": "2026-04-13T06:53:32Z",
+      "last_checked": "2026-05-23T00:37:17Z",
       "last_release": "1.9.1",
       "doc_path": "addons/Bank/index.md",
       "category": "addon"
     },
     "Biomes": {
-      "last_checked": "2026-05-09T22:22:00Z",
+      "last_checked": "2026-05-23T00:37:17Z",
       "last_release": "2.3.0",
       "doc_path": "addons/Biomes/index.md",
       "category": "addon"
     },
     "Border": {
-      "last_checked": "2026-04-26T12:00:00Z",
+      "last_checked": "2026-05-23T00:37:17Z",
       "last_release": "4.8.3",
       "doc_path": "addons/Border/index.md",
       "category": "addon"
     },
     "Challenges": {
-      "last_checked": "2026-04-13T06:53:32Z",
+      "last_checked": "2026-05-23T00:37:17Z",
       "last_release": "1.6.0",
       "doc_path": "addons/Challenges/index.md",
       "category": "addon"
     },
     "Chat": {
-      "last_checked": "2026-04-26T12:00:00Z",
+      "last_checked": "2026-05-23T00:37:17Z",
       "last_release": "1.4.1",
       "doc_path": "addons/Chat/index.md",
       "category": "addon"
     },
     "CheckMeOut": {
-      "last_checked": "2026-01-13T06:31:47Z",
+      "last_checked": "2026-05-23T00:37:17Z",
       "last_release": "",
       "doc_path": "addons/CheckMeOut/index.md",
       "category": "addon"
     },
     "ControlPanel": {
-      "last_checked": "2026-01-13T06:31:47Z",
+      "last_checked": "2026-05-23T00:37:17Z",
       "last_release": "",
       "doc_path": "addons/ControlPanel/index.md",
       "category": "addon"
     },
     "DimensionalTrees": {
-      "last_checked": "2026-04-15T12:15:40Z",
+      "last_checked": "2026-05-23T00:37:17Z",
       "last_release": "1.9.0",
       "doc_path": "addons/DimensionalTrees/index.md",
       "category": "addon"
     },
     "ExtraMobs": {
-      "last_checked": "2026-01-13T06:31:47Z",
+      "last_checked": "2026-05-23T00:37:17Z",
       "last_release": "",
       "doc_path": "addons/ExtraMobs/index.md",
       "category": "addon"
     },
     "FarmersDance": {
-      "last_checked": "2026-01-13T06:31:47Z",
+      "last_checked": "2026-05-23T00:37:17Z",
       "last_release": "",
       "doc_path": "addons/FarmersDance/index.md",
       "category": "addon"
     },
     "Greenhouses": {
-      "last_checked": "2026-01-13T06:31:47Z",
+      "last_checked": "2026-05-23T00:37:17Z",
       "last_release": "",
       "doc_path": "addons/Greenhouses/index.md",
       "category": "addon"
     },
     "InvSwitcher": {
-      "last_checked": "2026-05-09T22:22:00Z",
+      "last_checked": "2026-05-23T00:37:17Z",
       "last_release": "1.17.1",
       "doc_path": "addons/InvSwitcher/index.md",
       "category": "addon"
     },
     "IslandFly": {
-      "last_checked": "2026-01-13T06:31:47Z",
+      "last_checked": "2026-05-23T00:37:17Z",
       "last_release": "",
       "doc_path": "addons/IslandFly/index.md",
       "category": "addon"
     },
     "Level": {
-      "last_checked": "2026-05-17T06:34:07Z",
+      "last_checked": "2026-05-23T00:37:17Z",
       "last_release": "2.27.0",
       "doc_path": "addons/Level/index.md",
       "category": "addon"
     },
     "Likes": {
-      "last_checked": "2026-01-13T06:31:47Z",
+      "last_checked": "2026-05-23T00:37:17Z",
       "last_release": "",
       "doc_path": "addons/Likes/index.md",
       "category": "addon"
     },
     "Limits": {
-      "last_checked": "2026-04-13T06:53:32Z",
+      "last_checked": "2026-05-23T00:37:17Z",
       "last_release": "1.28.1",
       "doc_path": "addons/Limits/index.md",
       "category": "addon"
     },
     "MagicCobblestoneGenerator": {
-      "last_checked": "2026-01-13T06:31:47Z",
+      "last_checked": "2026-05-23T00:37:17Z",
       "last_release": "",
       "doc_path": "addons/MagicCobblestoneGenerator/index.md",
       "category": "addon"
     },
     "TopBlock": {
-      "last_checked": "2026-05-17T06:34:07Z",
+      "last_checked": "2026-05-23T00:37:17Z",
       "last_release": "2.0.0",
       "doc_path": "addons/TopBlock/index.md",
       "category": "addon"
     },
     "TwerkingForTrees": {
-      "last_checked": "2026-01-13T06:31:47Z",
+      "last_checked": "2026-05-23T00:37:17Z",
       "last_release": "",
       "doc_path": "addons/TwerkingForTrees/index.md",
       "category": "addon"
     },
     "Upgrades": {
-      "last_checked": "2026-04-14T00:44:27Z",
+      "last_checked": "2026-05-23T00:37:17Z",
       "last_release": "1.0.2",
       "doc_path": "addons/Upgrades/index.md",
       "category": "addon"
     },
     "Visit": {
-      "last_checked": "2026-01-13T06:31:47Z",
+      "last_checked": "2026-05-23T00:37:17Z",
       "last_release": "",
       "doc_path": "addons/Visit/index.md",
       "category": "addon"
     },
     "Warps": {
-      "last_checked": "2026-04-13T06:53:32Z",
+      "last_checked": "2026-05-23T00:37:17Z",
       "last_release": "1.19.0",
       "doc_path": "addons/Warps/index.md",
       "category": "addon"

--- a/docs/BentoBox/About/Teams.md
+++ b/docs/BentoBox/About/Teams.md
@@ -242,3 +242,14 @@ After flipping `isTeamsDisabled` on for a world that already has teams, run `/[a
     - All 22 bundled translations are in sync.
 
     **Compatibility:** Paper Minecraft 1.21.5 – 26.1.2, Java 21+.
+
+??? note "What's new in v3.16.2"
+    **Released:** 2026-05-19
+
+    Small follow-up patch. See the full notes: [Release 3.16.2](https://github.com/BentoBoxWorld/BentoBox/releases/tag/3.16.2)
+
+    - 🐛 **Team-accept no longer eats inventories under InvSwitcher.** Players who accepted a team invite while standing in a non-BentoBox world (with `island.reset.on-join.inventory: true` — Boxed and AOneBlock ship with this) could return to that world to find their items gone. The on-join inventory/XP/health/hunger/money resets now run *after* the teleport into the island world completes, so InvSwitcher (and similar plugins) save the player's real inventory under the old world before the reset fires. Fixes the case reported against AOneBlock 1.25.0 / Boxed 3.3.0 / InvSwitcher 1.17.1.
+    - 🔺 **API: `Island.setRange` no longer silently corrupts island data.** `setRange` now refuses any value that disagrees with the game mode's configured `distance-between-islands` and logs the calling stack frame. Game modes that legitimately resize claims (e.g., StrangerRealms) continue to work — they already override `GameModeAddon.isEnforceEqualRanges()` to return `false`. If you maintain an addon and see `Refusing Island.setRange(...)` warnings, the log names the exact caller.
+    - 🐛 **CraftEngine 26.5+ compatibility.** `CraftEngineHook.getItemStack(id)` now uses `BukkitItemDefinition#buildBukkitItem()` and works against the rewritten CraftEngine API.
+
+    **Compatibility:** Paper Minecraft 1.21.5 – 26.1.2, Java 21+.

--- a/docs/gamemodes/StrangerRealms/index.md
+++ b/docs/gamemodes/StrangerRealms/index.md
@@ -76,6 +76,20 @@ Permissions can be found [here](Permissions).
 
     **Compatibility:** BentoBox API 3.9.0+, Minecraft 1.21.10+, Java 21.
 
+!!! warning "What's new in v1.0.5 — Hotfix"
+    **Released:** 2026-05-19
+
+    Hotfix for a bug that could corrupt islands in other game modes sharing the same server. See the full notes: [Release 1.0.5](https://github.com/BentoBoxWorld/StrangerRealms/releases/tag/1.0.5)
+
+    - 🔺 **Fix `TeamListener` corrupting range on other game modes' islands.** When a player left a team or was kicked, the claim reset code was affecting islands belonging to other game modes (e.g., AOneBlock) on the same server. Upgrade immediately if you run StrangerRealms alongside another game mode.
+
+    **Recovery for affected servers.** If a previous StrangerRealms version corrupted other game modes' islands, those islands will still fail to load on startup with an `Island distance mismatch` error. To recover, either:
+
+    - Edit `plugins/BentoBox/database/Island/*.json` and set `range` back to the affected game mode's configured `distance-between-islands` (e.g. `400` for AOneBlock / BSkyBlock, `320` for Boxed), **or**
+    - Delete the offending island JSON files if losing them is acceptable.
+
+    **Compatibility:** BentoBox API 3.9.0+, Minecraft 1.21.10+, Java 21.
+
 ## Translations
 
 {{ translations("StrangerRealms") }}


### PR DESCRIPTION
## Summary

Documentation updates triggered by new releases detected since 2026-05-17:

| Repo | Previous | New |
|---|---|---|
| BentoBox | 3.16.1 | 3.16.2 |
| StrangerRealms | 1.0.4 | 1.0.5 |

## Changes per repo

### BentoBox (3.16.1 → 3.16.2)
- Added "What's new in v3.16.2" collapsible to `docs/BentoBox/About/Teams.md` covering:
  - 🐛 Team-accept inventory loss fix under InvSwitcher (defer on-join resets until after teleport)
  - 🔺 `Island.setRange` API hardening — refuses values disagreeing with the game mode's configured `distance-between-islands`
  - 🐛 CraftEngine 26.5+ compatibility (rewritten `CraftEngineHook.getItemStack`)

### StrangerRealms (1.0.4 → 1.0.5)
- Added "What's new in v1.0.5 — Hotfix" warning block to `docs/gamemodes/StrangerRealms/index.md`:
  - 🔺 Fix `TeamListener` corrupting range on other game modes' islands (companion to BentoBox 3.16.2 `setRange` guard)
  - Includes recovery instructions for servers affected by the prior bug (edit `range` in `Island/*.json` or delete the offending JSON)

## Verification

- [x] `mkdocs build --strict` passes with exit code 0 (only pre-existing GitHub-rate-limit warnings from the `translations()` macro)

🤖 Generated with [Claude Code](https://claude.ai/claude-code) using the `update-docs` skill