### PR TITLE
docs: update documentation for releases 2026-05-31

### DIFF
--- a/data/placeholders.csv
+++ b/data/placeholders.csv
@@ -123,3 +123,5 @@ TopBlock,aoneblock_island_phase_number_top_<number>,Phase number (e.g. Plains is
 TopBlock,aoneblock_island_count_top_<number>,Block Count of magic blocks mined this round at the `<number>` position, 1.0.1
 TopBlock,aoneblock_island_lifetime_top_<number>,Lifetime count of magic blocks mined at the `<number>` position, 1.0.1
 Border,Border_color,Current border color (red/green/blue) for the player,4.8.0
+InvSwitcher,[gamemode]_invswitcher_balance,The player's money balance for this gamemode's world,1.18.0
+InvSwitcher,[gamemode]_invswitcher_balance_formatted,The player's money balance for this gamemode's world formatted with currency name,1.18.0

--- a/data/release-tracker.json
+++ b/data/release-tracker.json
@@ -1,9 +1,9 @@
 {
-  "last_run": "2026-05-23T00:37:17Z",
+  "last_run": "2026-06-01T01:05:19Z",
   "repos": {
     "BentoBox": {
-      "last_checked": "2026-05-23T00:37:17Z",
-      "last_release": "3.16.2",
+      "last_checked": "2026-06-01T01:05:19Z",
+      "last_release": "3.17.0",
       "doc_path": "BentoBox/",
       "category": "core"
     },
@@ -20,8 +20,8 @@
       "category": "gamemode"
     },
     "Boxed": {
-      "last_checked": "2026-05-23T00:37:17Z",
-      "last_release": "",
+      "last_checked": "2026-06-01T01:05:19Z",
+      "last_release": "3.4.0",
       "doc_path": "gamemodes/Boxed/index.md",
       "category": "gamemode"
     },
@@ -74,14 +74,14 @@
       "category": "addon"
     },
     "Border": {
-      "last_checked": "2026-05-23T00:37:17Z",
-      "last_release": "4.8.3",
+      "last_checked": "2026-06-01T01:05:19Z",
+      "last_release": "4.8.4",
       "doc_path": "addons/Border/index.md",
       "category": "addon"
     },
     "Challenges": {
-      "last_checked": "2026-05-23T00:37:17Z",
-      "last_release": "1.6.0",
+      "last_checked": "2026-06-01T01:05:19Z",
+      "last_release": "1.6.1",
       "doc_path": "addons/Challenges/index.md",
       "category": "addon"
     },
@@ -128,8 +128,8 @@
       "category": "addon"
     },
     "InvSwitcher": {
-      "last_checked": "2026-05-23T00:37:17Z",
-      "last_release": "1.17.1",
+      "last_checked": "2026-06-01T01:05:19Z",
+      "last_release": "1.18.0",
       "doc_path": "addons/InvSwitcher/index.md",
       "category": "addon"
     },

--- a/docs/BentoBox/Developer-Documentation.md
+++ b/docs/BentoBox/Developer-Documentation.md
@@ -19,3 +19,45 @@ The core API package is `world.bentobox.bentobox.api.*`. Methods in those packag
 # Example Addon
 
 @BONNe maintains an example addon here: [https://github.com/BONNePlayground/ExampleAddon](https://github.com/BONNePlayground/ExampleAddon)
+
+# Cancellable player reset events
+
+*Added in BentoBox 3.17.0.*
+
+When a player leaves a team or their island is reset, BentoBox can clear their inventory, ender chest, money, health, hunger and XP, and untame their animals — depending on each game mode's `island.reset.on-leave` settings. Each of these reset actions now fires a **cancellable** event **before** it runs, so an addon can veto an individual reset instead of all-or-nothing. If a listener cancels the event, BentoBox skips that action.
+
+These events live in `world.bentobox.bentobox.api.events.player`:
+
+| Event | Fired before |
+| --- | --- |
+| `PlayerTamedRemovalEvent` | untaming the player's animals |
+| `PlayerResetEnderChestEvent` | clearing the ender chest |
+| `PlayerResetInventoryEvent` | clearing the inventory |
+| `PlayerResetMoneyEvent` | withdrawing the player's balance |
+| `PlayerResetHealthEvent` | resetting health |
+| `PlayerResetHungerEvent` | resetting hunger |
+| `PlayerResetExpEvent` | resetting XP |
+
+All events extend `PlayerBaseEvent` (which implements `Cancellable`) and carry the player UUID, the island, and the world. Listening is standard Bukkit:
+
+```java
+@EventHandler
+public void onInventoryReset(PlayerResetInventoryEvent e) {
+    if (shouldKeepInventory(e.getPlayerUUID())) {
+        e.setCancelled(true); // inventory will not be cleared
+    }
+}
+```
+
+Events are constructed and dispatched through a small builder API:
+
+```java
+PlayerEvent.builder()
+    .reason(PlayerEvent.Reason.INVENTORY_RESET)
+    .involvedPlayer(uuid)
+    .island(island)
+    .world(world)
+    .build();
+```
+
+This is purely additive — all classes are new and no existing API changed, so 3.17.0 is binary-compatible with existing addons. The [Inventory Switcher addon](../addons/InvSwitcher/index.md) uses these events to protect per-world inventories and balances during resets. See [Release 3.17.0](https://github.com/BentoBoxWorld/BentoBox/releases/tag/3.17.0).

--- a/docs/addons/Border/index.md
+++ b/docs/addons/Border/index.md
@@ -167,6 +167,16 @@ show-warps-on-map: true
 
     [Release v4.8.3](https://github.com/BentoBoxWorld/Border/releases/tag/4.8.3)
 
+??? note "What's new in v4.8.4"
+    **Released:** 2026-05-26
+
+    - 🐛 **Fixed `NoSuchMethodError: WorldBorder.changeSize` on Paper/Purpur 1.21.10.** The 4.8.3 build was compiled against Paper 1.21.11, which renamed the world-border lerp method, so the vanilla border type crashed on 1.21.10 servers when `/[player_command] bordertype vanilla` was used. Border now uses the cross-version `setSize` API and works on **both 1.21.10 and 1.21.11**.
+    - 🐛 Fixed the Modrinth publish workflow (incorrect artifact path).
+
+    No config or locale changes are required. If you worked around the bug with `bordertype barrier`, you can switch back to `vanilla` once 4.8.4 is installed.
+
+    [Release v4.8.4](https://github.com/BentoBoxWorld/Border/releases/tag/4.8.4)
+
 ## Translations
 
 {{ translations("Border") }}

--- a/docs/addons/Challenges/index.md
+++ b/docs/addons/Challenges/index.md
@@ -291,6 +291,15 @@ You can find more information how BentoBox custom GUI's works here: [Custom GUI'
 
     [Release v1.6.0](https://github.com/BentoBoxWorld/Challenges/releases/tag/1.6.0)
 
+??? note "What's new in v1.6.1"
+    **Released:** 2026-05-26
+
+    - 🐛 **Confirmation conversations no longer NPE on abandon.** The web library and the wipe/delete prompts in the admin GUI could flood the console with a `NullPointerException` when a confirmation conversation was abandoned instead of answered (for example, clicking a library entry several times before typing `confirm`, or letting the prompt time out). Abandons are now silently treated as no-ops.
+
+    Drop-in replacement — no config or locale changes are required.
+
+    [Release v1.6.1](https://github.com/BentoBoxWorld/Challenges/releases/tag/1.6.1)
+
 ## Translations
 
 !!! info "Translations for challenges"

--- a/docs/addons/InvSwitcher/index.md
+++ b/docs/addons/InvSwitcher/index.md
@@ -14,6 +14,7 @@ The following are switched per-world:
 * Experience
 * Health
 * Game mode (creative, survival, etc.)
+* Money (per-world economy, added in 1.18.0)
 
 ## How to use
 
@@ -51,6 +52,7 @@ options:
   experience: true
   ender-chest: true
   statistics: true
+  money: true          # Per-world money (added in 1.18.0). Requires Vault.
   # Per-island inventory switching (added in 1.17.0)
   # The world-level option must also be true for the island option to take effect.
   islands:
@@ -63,13 +65,53 @@ options:
     experience: false
     ender-chest: true
     statistics: false
+    money: false       # Per-island wallets (added in 1.18.0). False = per-world money only.
 ```
 
 Set `islands.active: true` to allow players who own more than one island to maintain separate inventories (and other aspects) per island, not just per gamemode world.
 
+### Economy
+
+Added in 1.18.0. When `options.money` is enabled, InvSwitcher registers itself as the Vault economy provider and keeps a **separate balance for each switched world**. Transactions (shop sales, `/pay`, jobs, etc.) are routed to the balance of the world they belong to — even when the target player is offline or in a different world. Worlds InvSwitcher does not manage are passed through to your existing economy plugin (e.g. EssentialsX); if no other economy is present, InvSwitcher handles every world itself.
+
+!!! warning "Requires Vault"
+    Per-world money requires the [Vault](https://www.spigotmc.org/resources/vault.34315/) plugin. A separate economy plugin is optional — InvSwitcher can be the only economy. If you run the **Bank** addon, island wallets become per-world too.
+
+The `economy:` block is only used when `options.money` is `true`:
+
+```yml
+economy:
+  starting-balance: 0.0              # Balance given on first entry to a managed world (unless imported)
+  currency-name-singular: Dollar
+  currency-name-plural: Dollars
+  fractional-digits: 2               # Digits after the decimal point
+  import-existing-balances: true     # Import each player's existing balance once, on first entry
+  delegate-unmanaged-worlds: true    # Pass unmanaged worlds through to the previous economy plugin
+  debug: false                       # Log every transaction to the console (verbose)
+```
+
 ## Commands
 
-There are no commands.
+Added in 1.18.0. Each managed game mode gains its own economy commands, scoped to that game mode's world, so `/bsb balance` shows your BSkyBlock balance and `/ai balance` your AcidIsland balance regardless of where you are standing.
+
+!!! tip
+    `[player_command]` and `[admin_command]` are the commands that differ depending on the gamemode you are running.
+
+=== "Player commands"
+
+    | Command | Description |
+    |---|---|
+    | `/[player_command] balance` | Show your money balance for this world |
+    | `/[player_command] pay <player> <amount>` | Pay another player |
+
+=== "Admin commands"
+
+    | Command | Description |
+    |---|---|
+    | `/[admin_command] eco give <player> <amount>` | Give money to a player |
+    | `/[admin_command] eco take <player> <amount>` | Take money from a player |
+    | `/[admin_command] eco set <player> <amount>` | Set a player's balance |
+    | `/[admin_command] eco balance <player>` | Show a player's balance |
 
 ## What it does
 This addon will give players a separate inventory, health, food level, advancements and experience for each gamemode installed and their corresponding worlds. It enables players to play each gamemode independently of each other.
@@ -100,6 +142,25 @@ This addon will give players a separate inventory, health, food level, advanceme
     - 🐛 **Fixed inventory cleared when teleporting from a BentoBox world to a non-BentoBox world.** When a player left a BentoBox game world (e.g. BSkyBlock) for a non-BentoBox world (e.g. the default overworld or a third-party plugin world), their "outside" inventory could be lost because each non-BentoBox world stored data under its own key. All non-BentoBox worlds now share a single storage key, so the player's inventory is always restored correctly. Includes automatic migration for data saved under the old per-world keys.
 
     [Release v1.17.1](https://github.com/BentoBoxWorld/InvSwitcher/releases/tag/1.17.1)
+
+??? warning "What's new in v1.18.0 — requires BentoBox 3.17.0"
+    **Released:** 2026-05-31
+
+    - 🔺⚙️🔡 **Per-world money.** InvSwitcher can now give every game world its own separate economy, on top of the inventories, health, XP and stats it already switches. With `options.money` enabled it registers itself as the Vault economy provider and routes every transaction to the correct world's balance — even when the player is offline or in a different world.
+    - ⚙️ **New config:** `options.money`, `options.islands.money`, and an `economy:` block (starting balance, currency names, fractional digits, import toggle, delegate toggle, debug). Existing configs keep working; the new keys are added with safe defaults.
+    - 🔡 **New commands & placeholders:** per-game-mode `balance` and `pay` for players, admin `eco give/take/set/balance`, plus `<gamemode>_invswitcher_balance` and `<gamemode>_invswitcher_balance_formatted` placeholders, translated into every language BentoBox ships.
+    - 🐛 Advancements no longer inflate experience on world switch.
+    - 🐛 BentoBox island resets no longer wipe the wrong world's inventory — InvSwitcher now clears the *stored* data for the correct world instead.
+
+    🔺 **Requires BentoBox 3.17.0:** InvSwitcher now listens to BentoBox's player-reset events (including the new money-reset event), which were introduced in 3.17.0. It will not load on older BentoBox versions.
+
+    🔺 **Economy behaviour change:** when `options.money` is enabled, InvSwitcher becomes the server's Vault economy provider. Worlds it does not manage are passed through to your existing economy (e.g. EssentialsX); managed worlds get their own per-world balance. Requires the Vault plugin.
+
+    [Release v1.18.0](https://github.com/BentoBoxWorld/InvSwitcher/releases/tag/1.18.0)
+
+## Placeholders
+
+{{ placeholders_source("InvSwitcher") }}
 
 ## Translations
 

--- a/docs/gamemodes/Boxed/index.md
+++ b/docs/gamemodes/Boxed/index.md
@@ -137,6 +137,22 @@ Commands can be found [here](Commands).
 
 Placeholders can be found [here](Placeholders).
 
+## Changelog
+
+??? note "What's new in v3.4.0"
+    **Released:** 2026-05-30
+
+    - **Trial Chambers support.** Boxed now captures and restores Trial Spawner state — including both the normal *and* ominous configurations — when structures are pulled from the seed world into a player's box, and recognises `trial_chambers` as a tracked structure for advancement-driven box growth.
+    - 🐛 **No more cross-game-mode progress loss.** Boxed no longer clears a player's advancements and statistics when an island is reset in a *different*, non-Boxed game mode.
+    - 🐛 Pending structure pastes are now cancelled when an island is deleted, preventing structures being placed into a box that no longer exists.
+    - 🐛 Ominous trial spawners now restore the correct configuration rather than always applying the normal one.
+    - Modernised build & test stack: Paper 1.21.11, BentoBox API 3.13.0, JUnit 5 + Mockito + MockBukkit.
+
+    !!! note
+        Trial Chambers are captured from the seed world when a box is generated, so boxes created *before* 3.4.0 will not retroactively gain them. New boxes (and newly expanded regions) will include them.
+
+    [Release v3.4.0](https://github.com/BentoBoxWorld/Boxed/releases/tag/3.4.0)
+
 ## Translations
 
 {{ translations("Boxed") }}


### PR DESCRIPTION
## Summary

Documentation updates triggered by new releases detected since 2026-05-23:

| Repo | Previous | New |
|---|---|---|
| BentoBox | 3.16.2 | 3.17.0 |
| Boxed | (undocumented) | 3.4.0 |
| Border | 4.8.3 | 4.8.4 |
| Challenges | 1.6.0 | 1.6.1 |
| InvSwitcher | 1.17.1 | 1.18.0 |

## Changes per repo

### BentoBox (3.16.2 → 3.17.0)
- Documented the new family of cancellable player reset events (`PlayerResetInventoryEvent`, `PlayerResetMoneyEvent`, etc.) in `Developer-Documentation.md`, including the event table, listener example, and builder API. Purely additive/binary-compatible API release.

### InvSwitcher (1.17.1 → 1.18.0)
- Added the new per-world **economy** feature: `options.money`, `options.islands.money`, and the full `economy:` config block (descriptions taken verbatim from `config.yml`).
- Replaced "There are no commands" with the new player (`balance`, `pay`) and admin (`eco give/take/set/balance`) command tabs.
- Added a **Placeholders** section + two rows to `data/placeholders.csv` (`[gamemode]_invswitcher_balance`, `..._balance_formatted`).
- Added "Money" to the per-world switched list and a `What's new in v1.18.0` warning block (requires BentoBox 3.17.0, Vault).

### Boxed (→ 3.4.0)
- Added a Changelog section with `What's new in v3.4.0` (Trial Chambers support, cross-game-mode progress fix, build modernisation).

### Border (4.8.3 → 4.8.4)
- Added `What's new in v4.8.4` (Paper 1.21.10 `WorldBorder.changeSize` compatibility fix).

### Challenges (1.6.0 → 1.6.1)
- Added `What's new in v1.6.1` (confirmation-conversation NPE-on-abandon hotfix).

## Verification

- [x] `mkdocs build --strict` passes with zero warnings (with `GITHUB_TOKEN` set to avoid the translations() rate limit)

🤖 Generated with [Claude Code](https://claude.com/claude-code) using the `update-docs` skill