### PR TITLE
docs: document Limits 1.28.2 (per-dimension limits)

### DIFF
--- a/data/release-tracker.json
+++ b/data/release-tracker.json
@@ -1,5 +1,5 @@
 {
-  "last_run": "2026-06-04T14:25:55Z",
+  "last_run": "2026-06-13T17:23:23Z",
   "repos": {
     "BentoBox": {
       "last_checked": "2026-06-01T01:05:19Z",
@@ -152,8 +152,8 @@
       "category": "addon"
     },
     "Limits": {
-      "last_checked": "2026-05-23T00:37:17Z",
-      "last_release": "1.28.1",
+      "last_checked": "2026-06-13T17:23:23Z",
+      "last_release": "1.28.2",
       "doc_path": "addons/Limits/index.md",
       "category": "addon"
     },

--- a/docs/addons/Limits/index.md
+++ b/docs/addons/Limits/index.md
@@ -24,20 +24,37 @@ There is a user command and an admin command called "limits". Admins can check t
 The config.yml has the following sections:
 
 * blocklimits
+* blocklimits-nether
+* blocklimits-end
 * worlds
 * entitylimits
+* entitylimits-nether
+* entitylimits-end
+
+!!! info "Per-dimension limits (1.28.2+)"
+    As of **1.28.2**, block counts, entity counts, limits, and offsets are tracked **independently for the overworld, nether, and end**. A single limit defined in `blocklimits` or `entitylimits` applies separately to each dimension — e.g. `HOPPER: 10` allows 10 hoppers in the overworld, 10 in the nether, and 10 in the end (30 total across the island). Use the optional `-nether` / `-end` sections to override a single dimension.
+
+    On first load after upgrading, your existing single-dimension data is migrated automatically into the **overworld** slot. The on-disk format changes, so take a backup before upgrading and note that downgrading afterwards is not supported.
 
 ### blocklimits
 
-This section lists the maximum number of blocks allowed for each block material. Do not use non-block materials because they will not work. The limits apply to all game worlds.
+This section lists the maximum number of blocks allowed for each block material. Do not use non-block materials because they will not work. The limits apply independently in every dimension (overworld, nether, end).
+
+### blocklimits-nether / blocklimits-end
+
+Optional sections that override the `blocklimits` defaults for the nether or the end respectively. They are commented out in the default config; uncomment and add entries to set dimension-specific block limits.
 
 ### worlds
 
-This section lists block limits for specific worlds. You must name the world specifically, e.g. AcidIsland_world and then list the materials and the limit.
+This section lists block limits for specific worlds. You must name the world specifically, e.g. AcidIsland_world and then list the materials and the limit. World-named limits override the dimension-default limit above for that specific world.
 
 ### entitylimits
 
-This section lists the default entity limits within a player's island space (protected area and to island limit). A limit of 5 will allow up to 5 entities in over world. Affects all types of creature spawning. Also includes entities like MINECARTS. Note that entity limits are no longer supported in the Nether and End because limits require chunks to be loaded to count entities and it causes too much lag.
+This section lists the default entity limits within a player's island space (protected area and to island limit). A limit of 5 will allow up to 5 entities. Affects all types of creature spawning. Also includes entities like MINECARTS. As of **1.28.2**, entity limits apply independently per dimension, so the nether and end are now counted and limited correctly (this fixes the long-standing bug where nether/end counts reset to zero on chunk unload).
+
+### entitylimits-nether / entitylimits-end
+
+Optional sections that override the `entitylimits` defaults for the nether or the end respectively. They are commented out in the default config; uncomment and add entries to set dimension-specific entity limits.
 
 Note: Only the first 49 limited blocks and entities are shown in the limits GUI.
 
@@ -62,11 +79,15 @@ entitygrouplimits:
 
 ## Permissions
 
-Island owners can have exclusive permissions that override the default or world settings. The format is:
+Island owners can have exclusive permissions that override the default or world settings. Two formats are supported:
 
-Format is `GAME-MODE-NAME.island.limit.MATERIAL.LIMIT`
+1. `GAME-MODE-NAME.island.limit.MATERIAL.LIMIT` — applied to every dimension.
 
-example: `bskyblock.island.limit.hopper.10`
+    example: `bskyblock.island.limit.hopper.10`
+
+2. `GAME-MODE-NAME.island.limit.ENV.MATERIAL.LIMIT` — applied to one dimension only, where `ENV` is one of `overworld`, `nether`, or `end` (1.28.2+).
+
+    example: `bskyblock.island.limit.nether.hopper.5`
 
 Permissions activate when the player logs in.
 
@@ -144,3 +165,17 @@ Some items cannot be limited (right now). The reasons are usually because there 
     - **Block names in the limits GUI are readable again.** Items were showing as `Minecraft:hopper` due to incorrect key formatting.
 
     [Release v1.28.1](https://github.com/BentoBoxWorld/Limits/releases/tag/1.28.1)
+
+??? warning "What's new in v1.28.2 — Per-dimension limits (data migration)"
+    **Released:** 2026-06-13
+
+    - 🔺⚙️ **Per-dimension limits.** Block counts, entity counts, limits, and offsets are now tracked independently for the overworld, nether, and end, fixing the long-standing bug where nether/end counts reset to zero on chunk unload ([#43](https://github.com/BentoBoxWorld/Limits/issues/43)). A single `blocklimits`/`entitylimits` value now applies to each dimension separately, with new optional `blocklimits-nether`, `blocklimits-end`, `entitylimits-nether`, and `entitylimits-end` override sections.
+    - 🔺 **Data migration.** Existing single-dimension data is migrated into the **overworld** slot on first load. The on-disk format changes, so take a backup before upgrading; downgrading afterwards is not supported.
+    - 🔺 **Per-dimension permissions.** A new 6-segment format, `<gamemode>.island.limit.<overworld|nether|end>.<KEY>.<NUMBER>`, scopes a limit to a single dimension. The existing 5-segment format still applies to all dimensions.
+    - 🐛 Accurate counting fixes: double-counted beds/doors ([#86](https://github.com/BentoBoxWorld/Limits/issues/86)), golem/snowman block removal anchored on the pumpkin ([#127](https://github.com/BentoBoxWorld/Limits/issues/127)), three entity-counting bugs, spawn eggs no longer consumed at the limit ([#134](https://github.com/BentoBoxWorld/Limits/issues/134)), and count leaks during recount.
+    - 🩹 Resolves a `NoSuchFieldError` crash on Minecraft 1.21.8 and earlier caused by referencing 1.21.9 copper blocks; these are now resolved by name.
+    - 🔡 All bundled locale files converted from legacy `&` colour codes to MiniMessage, and missing keys synced across all 21 languages. Review any customised locale strings against the new files.
+
+    Compatibility: BentoBox API 2.7.1 · Minecraft 1.21.5 – 26.1.2 · Java 21.
+
+    [Release v1.28.2](https://github.com/BentoBoxWorld/Limits/releases/tag/1.28.2)


### PR DESCRIPTION
## Summary

Documentation update triggered by a new release detected since the last run (2026-06-04):

| Repo | Previous | New |
|---|---|---|
| Limits | 1.28.1 | 1.28.2 |

## Changes

### Limits (1.28.1 → 1.28.2)
- Documented **per-dimension limits**: block/entity counts, limits, and offsets are now tracked independently for overworld, nether, and end.
- Added the new `blocklimits-nether`, `blocklimits-end`, `entitylimits-nether`, and `entitylimits-end` config sections to the Config section.
- Corrected the now-outdated note stating entity limits are unsupported in the Nether and End — they are now counted and limited per dimension (fixes #43).
- Documented the new 6-segment per-dimension permission format `<gamemode>.island.limit.<overworld|nether|end>.<KEY>.<NUMBER>`.
- Added a "What's new in v1.28.2" warning changelog block (data migration: existing data migrates into the overworld slot on first load; downgrading unsupported).
- Updated `data/release-tracker.json`.

No new flags or placeholders in this release.

## Verification

- [x] `mkdocs build --strict` passes with exit code 0

🤖 Generated with [Claude Code](https://claude.ai/claude-code) using the `update-docs` skill