### PR TITLE
docs: update documentation for releases 2026-06-15

### DIFF
--- a/data/placeholders.csv
+++ b/data/placeholders.csv
@@ -55,6 +55,7 @@ Bank,Bank_[gamemode]_visited_island_balance_formatted,Island balance of the isla
 Bank,Bank_[gamemode]_top_value_<number>,Island balance of the `<number>`-th island on the leader board,1.1.0
 Bank,Bank_[gamemode]_top_name_<number>,Island owner's name of the `<number>`-th island on the leader board,1.1.0
 Bank,Bank_[gamemode]_top_island_<number>,Island name of the `<number>`-th island on the leader board,1.10.0
+Bank,Bank_[gamemode]_latest_transaction,The player's most recent island bank transaction (rendered as `[Username] [TxType] $[Amount]`),1.10.0
 Challenges,[gamemode]_challenges_total_completion_count,Number of times the player completed challenges,0.8.3
 Challenges,[gamemode]_challenges_completed_count,Number of challenges the player has completed,0.8.3
 Challenges,[gamemode]_challenges_uncompleted_count,Number of challenges the player has not yet completed,0.8.3

--- a/data/release-tracker.json
+++ b/data/release-tracker.json
@@ -1,5 +1,5 @@
 {
-  "last_run": "2026-06-13T17:23:23Z",
+  "last_run": "2026-06-16T00:43:25Z",
   "repos": {
     "BentoBox": {
       "last_checked": "2026-06-01T01:05:19Z",
@@ -62,14 +62,14 @@
       "category": "gamemode"
     },
     "Bank": {
-      "last_checked": "2026-05-23T00:37:17Z",
-      "last_release": "1.9.1",
+      "last_checked": "2026-06-16T00:43:25Z",
+      "last_release": "1.10.0",
       "doc_path": "addons/Bank/index.md",
       "category": "addon"
     },
     "Biomes": {
-      "last_checked": "2026-05-23T00:37:17Z",
-      "last_release": "2.3.0",
+      "last_checked": "2026-06-16T00:43:25Z",
+      "last_release": "2.3.2",
       "doc_path": "addons/Biomes/index.md",
       "category": "addon"
     },
@@ -176,8 +176,8 @@
       "category": "addon"
     },
     "Upgrades": {
-      "last_checked": "2026-05-23T00:37:17Z",
-      "last_release": "1.0.2",
+      "last_checked": "2026-06-16T00:43:25Z",
+      "last_release": "1.0.3",
       "doc_path": "addons/Upgrades/index.md",
       "category": "addon"
     },

--- a/docs/addons/Bank/Placeholders.md
+++ b/docs/addons/Bank/Placeholders.md
@@ -20,6 +20,8 @@ These placeholders are available in all currently available gamemodes ([BSkyBloc
 | `%Bank_[gamemode]_visited_island_balance_formatted%` | Formatted island balance of the island the player is standing on. e.g. 1.2k | 1.1.0 |
 | `%Bank_[gamemode]_top_value_#RANK#%` | Island balance of the `#RANK#`-th island on the leader board | 1.1.0 |
 | `%Bank_[gamemode]_top_name_#RANK#%` | Island owner's name of the `#RANK#`-th island on the leader board | 1.1.0 |
+| `%Bank_[gamemode]_top_island_#RANK#%` | Island name of the `#RANK#`-th island on the leader board | 1.10.0 |
+| `%Bank_[gamemode]_latest_transaction%` | The player's most recent island bank transaction, rendered as `[Username] [TxType] $[Amount]` (e.g. `tastybento Deposited $500.0`) | 1.10.0 |
 
 *Note*: `#RANK#` is a number between 1 and the `number-of-ranks` setting in Bank's config.yml.
 

--- a/docs/addons/Bank/index.md
+++ b/docs/addons/Bank/index.md
@@ -117,6 +117,21 @@ You can [sponsor](https://github.com/sponsors/tastybento) to get more addons lik
 
 ## Changelog
 
+??? warning "What's new in v1.10.0 — Breaking changes (Java 21, BentoBox 3.14.0, MiniMessage)"
+    **Released:** 2026-06-16
+
+    A modernisation release. Bank now targets **Java 21, Paper 1.21.11 and BentoBox 3.14.0**, and its entire locale set has been migrated to BentoBox's **MiniMessage** colour format.
+
+    - 🔡 **New placeholder `%Bank_[gamemode]_latest_transaction%`** — shows a user's most recent island bank transaction, rendered as `[Username] [TxType] $[Amount]` (e.g. `tastybento Deposited $500.0`). Fully localised.
+    - 🔡 **Complete language coverage** — Bank now matches the full BentoBox locale set (23 languages).
+    - 🔡 🔺 **MiniMessage locale format.** All locale files were converted from legacy `&`/`§` colour codes to MiniMessage. Any customised Bank language files must be re-expressed in MiniMessage syntax — back them up, delete the old files to let them regenerate, then redo your edits.
+    - 🔺 **Platform modernization.** Build upgraded to Java 21 / Paper 1.21.11 / BentoBox 3.14.0; `plugin.yml` `api-version` bumped to 1.21; test suite migrated to JUnit 5 + MockBukkit.
+    - 🐛 Hardened bank transaction-history parsing against malformed entries and localised the latest-transaction placeholder fallback text.
+
+    🔺 **Updating:** Update BentoBox to 3.14.0 and ensure the server runs Java 21 **before** installing this version. Back up any customised locale files first.
+
+    [Release v1.10.0](https://github.com/BentoBoxWorld/Bank/releases/tag/1.10.0)
+
 ??? note "What's new in v1.9.1"
     **Released:** 2026-03-28
 

--- a/docs/addons/Biomes/index.md
+++ b/docs/addons/Biomes/index.md
@@ -257,6 +257,27 @@ You can find more information how BentoBox custom GUI's works here: [Custom GUI'
 
 ## Changelog
 
+??? note "What's new in v2.3.2"
+    **Released:** 2026-06-15
+
+    A small follow-up to 2.3.1 that completes the ocean-biome fix and repairs how the addon writes its config.
+
+    - ⚙️ **`change-ocean-biomes` is now in `config.yml`.** The option (added in 2.3.0) was never written to the shipped config template, so it didn't appear on disk and couldn't be configured.
+    - 🔧 **`config.yml` now self-heals on load.** Settings are written back after loading, so options added in new versions are added to existing configs automatically with their defaults — this was the root cause behind the option being invisible.
+
+    🔺 **Upgrading from 2.3.0 / 2.3.1 — no config edit needed.** On first load the config self-heals: `change-ocean-biomes` is written out as `true` automatically and biome changes work out of the box. (If you previously set it to `false` on purpose to preserve oceans, that value is kept.)
+
+    [Release v2.3.2](https://github.com/BentoBoxWorld/Biomes/releases/tag/2.3.2)
+
+??? warning "What's new in v2.3.1 — ocean islands fixed"
+    **Released:** 2026-06-14
+
+    - ⚙️🔺 **Biome changes apply to ocean islands again.** The `change-ocean-biomes` option (added in 2.3.0) defaulted to `false`, which made Biomes skip every block already in an ocean biome — so an all-ocean island (SkyBlock/AcidIsland void worlds, which are entirely `warm_ocean`) was skipped entirely while still reporting success. **The default is now `true`.** Fixes [#171](https://github.com/BentoBoxWorld/Biomes/issues/171).
+
+    🔺 **Note:** On a server upgrading from 2.3.0, the `change-ocean-biomes` line is not written to your existing `config.yml` automatically in this version, but the new default (`true`) takes effect in memory, so biome changes work again. This config-visibility gap is fully fixed in 2.3.2.
+
+    [Release v2.3.1](https://github.com/BentoBoxWorld/Biomes/releases/tag/2.3.1)
+
 ??? warning "What's new in v2.3.0 — requires BentoBox 3.14.0+ and Paper"
     **Released:** 2026-05-05
 

--- a/docs/addons/Upgrades/index.md
+++ b/docs/addons/Upgrades/index.md
@@ -130,6 +130,13 @@ The `UpgradeAPI` class is exposed for other addons to query and modify upgrade d
 
 ## Changelog
 
+??? note "What's new in v1.0.3"
+    **Released:** 2026-06-16
+
+    - 🐛 **Startup crash fixed.** Resolves a `ConcurrentModificationException` that could crash the addon on startup when an upgrade tier referenced a missing upgrade data entry (e.g. after partial seeding or manual data edits). Orphaned tiers are now skipped safely with a warning instead of aborting the whole addon load.
+
+    [Release v1.0.3](https://github.com/BentoBoxWorld/Upgrades/releases/tag/1.0.3)
+
 ??? warning "What's new in v1.0.0 — complete rewrite, action required"
     **Released:** 2026-04-12
 


### PR DESCRIPTION
## Summary

Documentation updates triggered by new releases detected since the last run (2026-06-13):

| Repo | Previous | New |
|---|---|---|
| Bank | 1.9.1 | 1.10.0 |
| Biomes | 2.3.0 | 2.3.2 |
| Upgrades | 1.0.2 | 1.0.3 |

## Changes per repo

### Bank (1.9.1 → 1.10.0)
- Added `%Bank_[gamemode]_latest_transaction%` placeholder to `data/placeholders.csv` and the Bank Placeholders page (also backfilled the missing `top_island` row).
- Added a "What's new in v1.10.0" changelog block flagging the breaking platform move (Java 21 / Paper 1.21.11 / BentoBox 3.14.0), the MiniMessage locale migration, full 23-language coverage, and the new placeholder.

### Biomes (2.3.0 → 2.3.2)
- Added "What's new in v2.3.1" changelog block — `change-ocean-biomes` default flipped to `true` so ocean (SkyBlock/AcidIsland void) islands get biome changes again (#171/#172).
- Added "What's new in v2.3.2" changelog block — `change-ocean-biomes` now written to the shipped `config.yml`, and config self-heals on load (#174/#175).

### Upgrades (1.0.2 → 1.0.3)
- Added "What's new in v1.0.3" changelog block — fixed a startup `ConcurrentModificationException` when an upgrade tier referenced a missing data entry; orphaned tiers are now skipped with a warning.

## Verification

- [x] `mkdocs build --strict` passes with zero warnings (with `GITHUB_TOKEN` set to lift the GitHub rate limit on the `translations()` macro)

🤖 Generated with [Claude Code](https://claude.com/claude-code) using the `update-docs` skill