### PR TITLE
docs: Limits upgrades walkthrough + island deletion FAQ

### DIFF
--- a/docs/FAQ.md
+++ b/docs/FAQ.md
@@ -183,6 +183,20 @@ BentoBox has no built-in shop. The pinned messages in `#support-en` describe two
 
 The visual border lives at the protection range. If a player has been granted a higher range permission but hasn't relogged, the border still shows the old radius. Have them rejoin (or use the admin range command which applies instantly).
 
+### I deleted an island but the blocks are still there — "This island is marked for deletion and is awaiting region cleanup"
+
+This is expected behaviour, not a bug. As of **BentoBox 3.16.1**, `/[admin_command] delete <player>` (and `/island reset`) removes the island from the database immediately — the player can make a new island straight away — but the **blocks are reaped on the next housekeeping sweep** (default: every 24 h) rather than instantly. Until then the area is flagged as "deleted" and you'll see the *awaiting region cleanup* message.
+
+The reap is delayed because BentoBox deletes the underlying region files, and one region file can hold **several islands** packed together. BentoBox will only delete a region file once **no live island** is left in it, so a deleted island whose region still hosts active neighbours stays on the map until those neighbours are also cleared.
+
+To act sooner:
+
+- **Force a sweep now:** run `/bbox admin purge deleted`. It reaps every soft‑deleted island whose region file is now empty — islands sharing a region with a live island are skipped.
+- **Shared region, need it gone immediately:** remove the blocks by hand with **WorldEdit** (`//pos1`/`//pos2`/`//set air`) or by regenerating the chunks. The island is already gone from the database; this is purely cosmetic block removal.
+- **Restart after purging** so Paper's chunk cache is cleared and the empty area stops rendering.
+
+See [Island Deletion (Admin)](BentoBox/About/IslandManagement.md#island-deletion-admin) for the full lifecycle.
+
 ## Teams, coop and visitors
 
 ### What's the difference between team, coop, trust and visit?

--- a/docs/addons/Upgrades/index.md
+++ b/docs/addons/Upgrades/index.md
@@ -14,7 +14,7 @@ Created and maintained by [tastybento](https://github.com/tastybento).
 1. Place the Upgrades addon jar in the addons folder of the BentoBox plugin.
 2. Restart the server.
 3. On first run, 8 example upgrades are seeded automatically so you can get started right away.
-4. Use `/[admin_command] upgrades` to customise or create upgrades in-game.
+4. Use `/[admin_command] upgrade` to customise or create upgrades in-game.
 
 ## How It Works
 
@@ -40,7 +40,7 @@ Each upgrade is made up of one or more **tiers**. A tier covers a range of level
     - `/[player_command] upgrade`: opens the upgrade purchase panel.
 
 === "Admin commands"
-    - `/[admin_command] upgrades`: opens the admin GUI to create, edit, and delete upgrades and their tiers.
+    - `/[admin_command] upgrade`: opens the admin GUI to create, edit, and delete upgrades and their tiers.
 
 ## Price Types
 
@@ -66,6 +66,32 @@ Each upgrade tier can grant any combination of the following rewards:
 | **Commands** | Runs console or player commands | At purchase |
 | **Spawner Boost** | Adds extra mob spawns to every spawner event on the island | Passive — always on |
 | **Crop Growth Boost** | Adds extra growth ticks to every natural crop growth event on the island | Passive — always on |
+
+### Block, Entity & Entity Group Limits
+
+The three Limits rewards all use the **same reward editor** and let you raise a per-island limit when an upgrade is purchased. They require the [Limits](../Limits/index.md) addon — without it the reward does nothing.
+
+!!! info "Upgrades *adds to* the base limit — it does not set it"
+    The **base (starting) limit** for a block, entity, or group is configured in the **Limits addon**, not here. A Limits reward only adds an **offset** on top of that base. Each purchased level adds the reward's amount again, so the player's effective limit is `Limits-addon base + (sum of upgrade offsets)`.
+
+    Example: if the Limits addon caps hoppers at `8` and a player buys 3 levels of an upgrade that adds `1` hopper per level, their island can place `8 + 3 = 11` hoppers.
+
+#### Configuring a limit reward
+
+1. Run `/[admin_command] upgrade` to open the admin GUI and create or select an upgrade.
+2. Open the upgrade, add a **tier** (an upgrade needs at least one tier), then open that tier and click **Rewards**.
+3. Create a new **Limits** reward (the barrier icon). The reward editor has three settings:
+
+| Setting | What it does |
+|---|---|
+| **Type** | Click to cycle between `BLOCK`, `ENTITY`, and `ENTITY_GROUP`. Choose `BLOCK` to limit a block such as a hopper. |
+| **Target** | The thing being limited. Type it in chat. For `BLOCK` use a Bukkit [Material](https://hub.spigotmc.org/javadocs/bukkit/org/bukkit/Material.html) name (e.g. `HOPPER`, `CHEST`); for `ENTITY` an [EntityType](https://hub.spigotmc.org/javadocs/bukkit/org/bukkit/entity/EntityType.html) name (e.g. `CHICKEN`); for `ENTITY_GROUP` a group name that **matches a group defined in the Limits addon**. |
+| **Amount** | How much the limit is raised **per level**. Accepts a plain number or a formula using the [Formula Variables](#formula-variables) (e.g. `1`, or `[level] * 2`). |
+
+A green pane in the reward editor means the configuration is valid; a red pane means a required field (usually the Target) is still missing.
+
+!!! tip "Different blocks need different upgrades or tiers"
+    Each Limits reward targets a single block/entity/group. To raise the limit on several block types, add a separate Limits reward for each one — either as multiple rewards on the same tier or as separate upgrades — and give each its own Target.
 
 ### Commands
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -15,6 +15,7 @@ hide:
 
   <div class="bb-cta-row">
     <a href="BentoBox/First-Steps" class="bb-btn bb-btn-primary">First 30 minutes &rarr;</a>
+    <a href="FAQ" class="bb-btn bb-btn-ghost">FAQ &amp; troubleshooting</a>
     <a href="gamemodes/Comparison" class="bb-btn bb-btn-ghost">Choose a game mode</a>
     <a href="https://download.bentobox.world" class="bb-btn bb-btn-ghost">Download builds</a>
   </div>


### PR DESCRIPTION
## Summary

- Explain how to configure Limits upgrades (block/entity/group)
- Add a searchable FAQ entry for the "marked for deletion and awaiting region cleanup" behaviour (BentoBox 3.16.1+ delayed region reap), prompted by [BentoBox#2992](https://github.com/BentoBoxWorld/BentoBox/issues/2992)
- Add an "FAQ & troubleshooting" button to the homepage hero CTA row so the FAQ is easier to find

## Notes

- `mkdocs build` passes cleanly.
- The new FAQ entry is titled with the exact in-game message so it surfaces in site search, and links to the canonical [Island Deletion (Admin)](https://docs.bentobox.world/en/latest/BentoBox/About/IslandManagement/#island-deletion-admin) section.

🤖 Generated with [Claude Code](https://claude.com/claude-code)