### PR TITLE
docs: update documentation for releases 2026-07-03

### DIFF
--- a/data/placeholders.csv
+++ b/data/placeholders.csv
@@ -115,6 +115,8 @@ MagicCobblestoneGenerator,[gamemode]_magiccobblestonegenerator_max_active_genera
 MagicCobblestoneGenerator,[gamemode]_magiccobblestonegenerator_active_generator_names,List of active generator names separated with comma,2.2.0
 MagicCobblestoneGenerator,[gamemode]_magiccobblestonegenerator_unlocked_generator_names,List of unlocked generator names separated with comma,2.2.0
 MagicCobblestoneGenerator,[gamemode]_magiccobblestonegenerator_purchased_generator_names,List of purchased generator names separated with comma,2.2.0
+MagicCobblestoneGenerator,[gamemode]_magiccobblestonegenerator_generator_exhaustion_status,Exhaustion status (generated count / limit) for every active generator on the player island,2.8.0
+MagicCobblestoneGenerator,[gamemode]_magiccobblestonegenerator_exhausted_generator_names,List of the player island's generators that are currently on exhaustion cooldown separated with comma,2.8.0
 Limits,Limits_[gamemode]_island_[material]_count,Current count of material (lower cased) on the island,1.17.2
 Limits,Limits_[gamemode]_island_[material]_limit,The limit of material (lower cased) for the island,1.17.2
 TopBlock,aoneblock_island_player_name_top_<number>,Island owner's name at the `<number>` position, 1.0.1

--- a/data/release-tracker.json
+++ b/data/release-tracker.json
@@ -1,9 +1,9 @@
 {
-  "last_run": "2026-06-16T00:43:25Z",
+  "last_run": "2026-07-03T00:00:00Z",
   "repos": {
     "BentoBox": {
-      "last_checked": "2026-06-01T01:05:19Z",
-      "last_release": "3.17.0",
+      "last_checked": "2026-07-03T00:00:00Z",
+      "last_release": "3.18.1",
       "doc_path": "BentoBox/",
       "category": "core"
     },
@@ -14,8 +14,8 @@
       "category": "gamemode"
     },
     "AOneBlock": {
-      "last_checked": "2026-05-23T00:37:17Z",
-      "last_release": "1.25.0",
+      "last_checked": "2026-07-03T00:00:00Z",
+      "last_release": "1.25.1",
       "doc_path": "gamemodes/AOneBlock/index.md",
       "category": "gamemode"
     },
@@ -32,14 +32,14 @@
       "category": "gamemode"
     },
     "CaveBlock": {
-      "last_checked": "2026-05-23T00:37:17Z",
-      "last_release": "",
+      "last_checked": "2026-07-03T00:00:00Z",
+      "last_release": "1.21.0",
       "doc_path": "gamemodes/CaveBlock/index.md",
       "category": "gamemode"
     },
     "poseidon": {
-      "last_checked": "2026-05-23T00:37:17Z",
-      "last_release": "",
+      "last_checked": "2026-07-03T00:00:00Z",
+      "last_release": "1.1.1",
       "doc_path": "gamemodes/Poseidon/index.md",
       "category": "gamemode"
     },
@@ -62,8 +62,8 @@
       "category": "gamemode"
     },
     "Bank": {
-      "last_checked": "2026-06-16T00:43:25Z",
-      "last_release": "1.10.0",
+      "last_checked": "2026-07-03T00:00:00Z",
+      "last_release": "1.10.1",
       "doc_path": "addons/Bank/index.md",
       "category": "addon"
     },
@@ -80,8 +80,8 @@
       "category": "addon"
     },
     "Challenges": {
-      "last_checked": "2026-06-01T01:05:19Z",
-      "last_release": "1.6.1",
+      "last_checked": "2026-07-03T00:00:00Z",
+      "last_release": "1.7.0",
       "doc_path": "addons/Challenges/index.md",
       "category": "addon"
     },
@@ -128,8 +128,8 @@
       "category": "addon"
     },
     "InvSwitcher": {
-      "last_checked": "2026-06-01T01:05:19Z",
-      "last_release": "1.18.0",
+      "last_checked": "2026-07-03T00:00:00Z",
+      "last_release": "1.19.1",
       "doc_path": "addons/InvSwitcher/index.md",
       "category": "addon"
     },
@@ -152,14 +152,14 @@
       "category": "addon"
     },
     "Limits": {
-      "last_checked": "2026-06-13T17:23:23Z",
-      "last_release": "1.28.2",
+      "last_checked": "2026-07-03T00:00:00Z",
+      "last_release": "1.28.3",
       "doc_path": "addons/Limits/index.md",
       "category": "addon"
     },
     "MagicCobblestoneGenerator": {
-      "last_checked": "2026-05-23T00:37:17Z",
-      "last_release": "",
+      "last_checked": "2026-07-03T00:00:00Z",
+      "last_release": "2.8.0",
       "doc_path": "addons/MagicCobblestoneGenerator/index.md",
       "category": "addon"
     },

--- a/docs/BentoBox/About/AdminTools.md
+++ b/docs/BentoBox/About/AdminTools.md
@@ -34,6 +34,8 @@ Each game mode has its own admin command. For BSkyBlock it's `/bsb`, for AcidIsl
 | `/[admin] info <player>` | Shows full details of a player's island |
 | `/[admin] delete <player>` | Deletes a player's island |
 | `/[admin] setrange <player> <range>` | Changes a player's island protection range |
+| `/[admin] range removebonus <player> [id]` | Removes all bonus protection ranges from a single island, or just those for a given id |
+| `/[admin] range purgebonus <id>` | Removes a bonus range id from **every** island in the world — ideal after uninstalling an addon that granted bonus ranges. The scan runs asynchronously so it won't freeze large servers |
 | `/[admin] settings` | Opens the world settings panel for admins |
 | `/[admin] settings <player>` | Opens the island settings panel for a specific player |
 | `/[admin] why <player>` | Starts tracking why a player can or cannot do something (see below) |
@@ -97,3 +99,25 @@ After changing a config file, you can apply it without fully restarting the serv
 /bentobox reload
 ```
 This reloads BentoBox and all addons, including locales. Note that some changes (like world generation settings) always require a full restart to take effect.
+
+## Changelog
+
+!!! warning "What's new in v3.18.0 — Minecraft 26.2 support requires Java 25 (server)"
+    **Released:** 2026-06-27
+
+    - 🔺 **Minecraft 26.2 support + Java 25.** BentoBox now runs on the Minecraft 26.x line (26.2 supported at runtime) and the build has migrated to the Java 25 toolchain. **Your server must run on a Java 25-capable Paper build for the 26.x line.** Already-built addon jars keep working unchanged — only addon *developers* recompiling against this release need to move their own build to Java 25. Compatibility: Paper Minecraft 1.21.5 – 26.2, Java 25+.
+    - ⚙️ **Dynmap island marker / area toggles.** A new `dynmap` section in `config.yml` adds `island-markers` (the house icon at the centre of every island) and `island-areas` (the protected-area border box) switches. Both default to `true`, preserving existing behaviour; set either to `false` and run `/bbox reload` to hide those overlays on servers where dense islands flood the map.
+    - **Admin range bonus management.** New `/[admin] range removebonus` and `/[admin] range purgebonus` commands clear bonus protection ranges from one island or every island — ideal after uninstalling an addon that granted them (see the Per-Game-Mode Admin Commands table above).
+    - 🐛 `/is team setowner` is no longer blocked by the island limit when transferring to an existing team member.
+    - 🐛 The Vault hook now retries after addons enable, fixing economy integration that depended on load order.
+
+    [Release v3.18.0](https://github.com/BentoBoxWorld/BentoBox/releases/tag/3.18.0)
+
+??? note "What's new in v3.18.1"
+    **Released:** 2026-07-01
+
+    Maintenance release.
+
+    - 🐛 **Multi-line lore & names keep their colour.** Text after the first line of a GUI tooltip no longer falls back to the default purple — the serializer now re-emits the active colour (and decorations) after each newline, fixing tooltips across all addons.
+
+    [Release v3.18.1](https://github.com/BentoBoxWorld/BentoBox/releases/tag/3.18.1)

--- a/docs/addons/Bank/index.md
+++ b/docs/addons/Bank/index.md
@@ -117,6 +117,15 @@ You can [sponsor](https://github.com/sponsors/tastybento) to get more addons lik
 
 ## Changelog
 
+??? note "What's new in v1.10.1"
+    **Released:** 2026-06-21
+
+    Bug-fix release — drop-in replacement, no config or locale changes.
+
+    - 🐛 **Bank no longer disables itself when the economy is provided by an addon.** BentoBox hooks Vault during its early-hook phase, before addons enable. If no economy plugin had registered a provider by then, that early hook was discarded — so when the economy came from an addon (e.g. [InvSwitcher](../InvSwitcher/index.md), which registers a per-world Vault economy in its own `onEnable()`), Bank found no Vault provider and shut itself down with *"Vault is required"*. Bank now retries the Vault hook before giving up, and declares `InvSwitcher` as a `softdepend` so it enables first when present, making the load order deterministic.
+
+    [Release v1.10.1](https://github.com/BentoBoxWorld/Bank/releases/tag/1.10.1)
+
 ??? warning "What's new in v1.10.0 — Breaking changes (Java 21, BentoBox 3.14.0, MiniMessage)"
     **Released:** 2026-06-16
 

--- a/docs/addons/Challenges/index.md
+++ b/docs/addons/Challenges/index.md
@@ -41,6 +41,14 @@ The example template file: [template.yml](https://github.com/BentoBoxWorld/Chall
     - Other Challenge (`OTHER_TYPE`) - challenge that requires player XP, money or island level to be completed.
     - Statistic Challenge (`STATISTIC_TYPE`) - challenge that requires certain value from player statistic to be completed.
 
+??? question "What are team challenges?"
+    Since **1.7.0**, any challenge can additionally be marked as a **team challenge** — a challenge that is only available to islands with a team. Team challenges can require a configurable percentage of the team to be online before they can be completed, and support two collaborative modes:
+
+    - **Aggregate ("Pooled Tribute")** — the required items or statistics are summed across the online members. When items are consumed, the cost is split equitably across contributors: everyone chips in equally, and anyone short gives what they have while the rest cover the difference.
+    - **Per-member ("Roll Call Feast")** — every present member must contribute their own share, so no one can freeload; the configured amount is the team total, split across the online members.
+
+    Rewards go to every online member, completion and cooldown are shared by the whole team, and team statistic challenges only count progress earned *while on the team*. Team challenges can be shown greyed-out to soloists as a recruitment nudge or hidden entirely. Five reference challenges — **All Hands on Deck**, **Pooled Tribute**, **Synchronized Build**, **Combined Effort** and **Roll Call Feast** — ship in the bundled `default.json`, and the admin challenge editor exposes toggles for all of the new options.
+
 ??? question "Can I specify an enchantment on required/reward items?"
     Unfortunately Spigot does not have a general item parsing mechanics. So plugin authors need to create their own. Challenges addon uses BentoBox [Item Parser](/en/latest/BentoBox/ItemParser/). If function is not supported by it, then you cannot. However, you can always use in-game admin GUI to set any items you want. There is not any limitation.
 
@@ -275,6 +283,17 @@ You can find more information how BentoBox custom GUI's works here: [Custom GUI'
     ```
 
 ## Changelog
+
+??? note "What's new in v1.7.0"
+    **Released:** 2026-07-01
+
+    - 🔡 **Team challenges** — a brand-new class of challenge built for island teams. Team challenges only appear for players who have a team, can require a share of the team to be online, and can either pool resources or ask every member to chip in. Five ready-to-use examples ship in the bundled challenge set. See the *"What are team challenges?"* FAQ above for details.
+    - **Clearer import errors.** Failures while importing challenges are now reported back to the admin running the import, with details, instead of being silently written to the console log.
+    - 🔡 **All translations refreshed** — every locale file was synced with the English source, including the new team-challenge strings. If you maintain custom translations, re-check them against `en-US.yml`, as several new keys were added (team-challenge buttons, errors and lore).
+
+    Existing challenges are unaffected — all team behaviour is opt-in and defaults to off. Requires BentoBox 3.14.0+.
+
+    [Release v1.7.0](https://github.com/BentoBoxWorld/Challenges/releases/tag/1.7.0)
 
 ??? warning "What's new in v1.6.0 — locale regeneration required"
     **Released:** 2026-04-13

--- a/docs/addons/InvSwitcher/index.md
+++ b/docs/addons/InvSwitcher/index.md
@@ -127,6 +127,25 @@ This addon will give players a separate inventory, health, food level, advanceme
 
 ## Changelog
 
+??? note "What's new in v1.19.1"
+    **Released:** 2026-07-02
+
+    Bug-fix release — drop-in replacement, no config or locale changes.
+
+    - 🐛 **Fixed per-island health death loop.** With per-island health enabled, a player who owned more than one island could get trapped in an endless respawn/death screen after dying. When their state was captured mid-death it recorded a health of `0`; loading that value back on the death island applied `setHealth(0)`, killing them again the instant the world loaded. InvSwitcher now never applies a fatal stored health to a live player — a stored value of `0` (only ever produced mid-death) restores full health instead, matching vanilla respawn behaviour.
+
+    [Release v1.19.1](https://github.com/BentoBoxWorld/InvSwitcher/releases/tag/1.19.1)
+
+??? note "What's new in v1.19.0"
+    **Released:** 2026-06-21
+
+    Follow-up to the 1.18.0 per-world economy release. Drop-in replacement — no config or locale changes.
+
+    - 🐛 **Standalone economy now works on its own.** InvSwitcher registers its own per-world Vault economy, but BentoBox hooks Vault before addons enable, so when InvSwitcher was the only economy on the server that early hook found nothing and was discarded — and economy-dependent addons such as **Bank** disabled themselves with *"Vault is required"*. InvSwitcher now registers a fresh Vault hook with BentoBox once its provider is live, so it works as the server's only economy (no separate economy plugin such as EssentialsX is needed).
+    - 🐛 **Correct balance reported for offline economy transactions.** Admin `eco give/set/take` on an offline player reported a stale balance (e.g. "New balance: 0.00" right after giving 2,000). The money was always stored correctly; the confirmation message re-read the balance before the asynchronous save had flushed. Commands now report the authoritative balance returned by the transaction itself, and the offline read-after-write path was hardened so two rapid sequential transactions can no longer lose an update.
+
+    [Release v1.19.0](https://github.com/BentoBoxWorld/InvSwitcher/releases/tag/1.19.0)
+
 ??? note "What's new in v1.17.0"
     **Released:** 2026-03-31
 

--- a/docs/addons/Limits/index.md
+++ b/docs/addons/Limits/index.md
@@ -145,6 +145,16 @@ Some items cannot be limited (right now). The reasons are usually because there 
 
 ## Changelog
 
+??? note "What's new in v1.28.3"
+    **Released:** 2026-06-29
+
+    Bug-fix release — no data, config or locale changes; a drop-in replacement that makes per-island **entity counts** reliable across server restarts.
+
+    - 🐛 **Entity counts no longer drift after a restart.** The map linking each entity to its island was kept in memory only and lost on every restart. Entities reloaded from chunks never re-entered it, so when they later died or despawned **off-island** their count was never decremented and slowly crept upward. Entities are now re-registered as their chunks load, so off-island removals decrement correctly again.
+    - 🩹 **No more map growth on chunk unload.** The in-memory mapping is now released when a chunk unloads (and rebuilt on reload), preventing unbounded growth on long-running servers.
+
+    [Release v1.28.3](https://github.com/BentoBoxWorld/Limits/releases/tag/1.28.3)
+
 ??? warning "What's new in v1.28.0 — Java 21 required"
     **Released:** 2026-04-01
 

--- a/docs/addons/MagicCobblestoneGenerator/index.md
+++ b/docs/addons/MagicCobblestoneGenerator/index.md
@@ -114,6 +114,41 @@ Template file are mostly for users who do not like to use ingame editing GUI. Ho
           - generator_id_2
     ```
 
+### Generator exhaustion (rate limiting)
+
+Since **2.8.0** generators can be capped so they only produce a set number of blocks within a time period before going on cooldown — useful for discouraging fully-automated AFK farms. The feature is **opt-in and disabled by default** (a limit of `0`), so existing setups are unaffected until you enable it. When a generator is temporarily on cooldown, players receive a `generator-exhausted` message.
+
+=== "exhaustion.limit"
+    !!! summary "Description"
+        The default number of blocks a generator may produce during a single exhaustion period. `0` or less disables the limitation (the default). Each generator tier can override this via the per-tier `exhaustion-limit` key (see below).
+
+        Default: `0`
+
+=== "exhaustion.period"
+    !!! summary "Description"
+        The length of the exhaustion period, in **minutes**. The block count resets at the end of each period.
+
+        Default: `60`
+
+=== "exhaustion.cooldown"
+    !!! summary "Description"
+        How long, in **minutes**, a generator stays on cooldown after reaching its exhaustion limit.
+
+        Default: `1440` (24 hours)
+
+=== "exhaustion.notification-cooldown"
+    !!! summary "Description"
+        The minimum time, in **seconds**, between two exhaustion warning messages shown to the same player.
+
+        Default: `60`
+
+!!! tip "Per-tier limit"
+    Each generator tier can override the global limit with an `exhaustion-limit` key in the generator template (and in the admin GUI), so different tiers can be throttled independently.
+
+### Per-block height ranges
+
+Also since **2.8.0**, generators — and individual blocks within a generator — can be limited to a minimum and maximum Y level, so different materials are produced at different heights. New GUI buttons let admins set and clear the range, and the generator lore shows players where each generator operates. Legacy templates without a height range remain fully compatible.
+
 ## Commands
 
 !!! tip
@@ -261,6 +296,19 @@ Template file are mostly for users who do not like to use ingame editing GUI. Ho
               basalt: "&8 Basalt Generators"
               any: "&7&l Supports &e&o all &r&7&l generators"
     ```
+
+## Changelog
+
+!!! warning "What's new in v2.8.0 — requires BentoBox 3.14.0 / Java 21"
+    **Released:** 2026-07-03
+
+    - ⚙️ **Generator exhaustion.** Optionally rate-limit how many blocks a generator produces per period, with a cooldown once the limit is hit. Configurable globally (`exhaustion.*` in `config.yml`) and per generator tier (`exhaustion-limit` in the template). Opt-in and disabled by default. See the Configuration section above.
+    - **Per-block height ranges.** Restrict generators and individual blocks to a minimum/maximum Y level, with new GUI controls and player-facing lore.
+    - 🔡 **New placeholders** `[gamemode]_magiccobblestonegenerator_generator_exhaustion_status` and `[gamemode]_magiccobblestonegenerator_exhausted_generator_names` expose exhaustion state.
+    - 🔡 🔺 **MiniMessage locales + 13 new languages.** Every locale file was converted from legacy `&`/`§` colour codes to MiniMessage (which BentoBox 3.14 renders natively), and translations were added for cs, hr, hu, id, it, ja, ko, lv, nl, pt, pt-BR, ro and zh-HK — 24 locales in total, matching BentoBox core. If you kept custom edits to any `locales/*.yml`, re-apply them in MiniMessage format (or delete the file to regenerate a fresh one).
+    - 🔺 **Modernised for BentoBox 3.14 / Java 21.** Updated to the current BentoBox API and Paper, with the test suite migrated to MockBukkit. This release will not load on older BentoBox or Java versions — update BentoBox first.
+
+    [Release v2.8.0](https://github.com/BentoBoxWorld/MagicCobblestoneGenerator/releases/tag/2.8.0)
 
 ## Translations
 

--- a/docs/gamemodes/AOneBlock/index.md
+++ b/docs/gamemodes/AOneBlock/index.md
@@ -687,3 +687,13 @@ AOneBlock has some custom events that are called only in AOneBlock. But BentoBox
     🔺 If you want the new bee nest, copy the new entry into your `phases/8500_plenty.yml` (or delete the phases folder so it regenerates) — customised phase files are not overwritten on upgrade.
 
     [Release v1.25.0](https://github.com/BentoBoxWorld/AOneBlock/releases/tag/1.25.0)
+
+??? note "What's new in v1.25.1"
+    **Released:** 2026-07-03
+
+    Bug-fix release — drop-in replacement, no config or locale changes.
+
+    - 🐛 **Miner minions can mine the magic block again.** Breaking the magic block with a JetsMinions Miner minion threw a `NullPointerException` and left the block missing until it was manually restored with `/ob respawnblock`. The minion break path no longer runs the player-only magic-block protection check that caused the crash, so the block cycles and respawns as expected. This regression had been present since 1.22.0.
+    - 🐛 **`my_island_*` placeholders fixed for visiting team members.** When a player who belongs to a team visited another island, the `my_island_*` placeholders resolved to the visited island's team data instead of the player's own island. They now always resolve to the player's own island.
+
+    [Release v1.25.1](https://github.com/BentoBoxWorld/AOneBlock/releases/tag/1.25.1)

--- a/docs/gamemodes/CaveBlock/index.md
+++ b/docs/gamemodes/CaveBlock/index.md
@@ -29,67 +29,26 @@ After addon is successfully installed, it will create config.yml file. Every opt
 
 You can find the latest config file: [config.yml](https://github.com/BentoBoxWorld/CaveBlock/blob/develop/src/main/resources/config.yml)
 
+!!! info "World generation reworked in 1.21.0"
+    Since **1.21.0** the overworld is carved by Minecraft's own vanilla 1.18+ noise generator, so islands run through genuine cheese, spaghetti, lush, dripstone and deep-dark caves — complete with vanilla ores, decorations, structures and underground biomes. Every column is then capped so the world stays solid rock with no open sky. Because the server now handles carving, ores and biomes, the old block-replacement generation options (`generation-tries`, `use-new-material-generator`, the per-dimension `blocks` lists, and the `natural-*` toggles) were removed. The Nether and End keep a fill-and-decorate approach with a new ore-vein populator. See the changelog at the bottom of this page before upgrading.
+
 === "world.world-depth"
     !!! summary "Description"
         The depth of world indicates till which height blocks will be generated in world. Setting it to -64 will create just a basic void world.
 
         Allows to create some fresh air above your cave.
 
-=== "world.generation-tries"
-    !!! summary "Description"
-        This allows to specify how many tries will it take to change a main dimension block with an ore block.
-
-=== "world.use-new-material-generator"
-    !!! summary "Description"
-        Improve material generator generates vanillish ore bolbs, granite, diorite and tuff patches, as well as uses some deepslate.
-
-        However, it will disable any customization you are adding via dimension block configs.
-
 === "world.normal.roof"
     !!! summary "Description"
         Allows toggling if overworld top block should be bedrock block. Otherwise, it will be made of stone.
-
-=== "world.normal.natural-surface"
-    !!! summary "Description"
-        Option allows toggling if world generator should generate natural(-ish) looking surface with dirt and grass blocks. 
-        Currently, natural(-ish) is just dirt and grass block layers.
-
-        This option disables `world.normal.roof` option.
-
-=== "world.normal.natural-caves"
-    !!! summary "Description"
-        Option allows toggling if world generator should generate natural caves like in vanilla world.
-        Caves will be generated with all blocks and biomes.
 
 === "world.normal.floor"
     !!! summary "Description"
         Allows toggling if overworld bottom block should be bedrock block. Otherwise, it will be made of stone.
 
-=== "world.normal.natural-bedrock"
-    !!! summary "Description"
-        Allows toggling if overworld bedrock should be generated like in vanilla world with 4 block height.
-
 === "world.normal.main-block"
     !!! summary "Description"
-        Allows setting main block that will be used for overworld generation. Setting it to AIR will create void world.
-
-=== "world.normal.blocks"
-    !!! summary "Description"
-        Blocks that will occasionally replace main block by random chance.
-        Blocks will replace only main-block and will try to create packs that
-        are set in their strings. Chance of spawning also is required.
-        
-        For materials first string must be MATERIAL, for entity: ENTITY.
-        
-        Entities spawned via generator are not protected from despawing.
-        Working only with 2 high mobs currently.
-
-    !!! example "Example"
-        ```yaml
-            blocks:
-                - MATERIAL:DIAMOND_ORE:100:5 
-        ```        
-        Means there is 100% chace of spawing diamonds where max amount in pack are 5 per each subchunk!
+        Main block used to cap the sky gaps above the vanilla-generated terrain. Vanilla cave carving, ores, structures and underground biomes (lush caves, dripstone caves, deep dark) are produced by the server; this setting only affects the material used to fill the surface layer. Setting it to AIR will leave open sky above the caves.
 
 === "world.nether.roof"
     !!! summary "Description"
@@ -101,25 +60,7 @@ You can find the latest config file: [config.yml](https://github.com/BentoBoxWor
 
 === "world.nether.main-block"
     !!! summary "Description"
-        Allows setting main block that will be used for the nether world generation. Setting it to AIR will create void world.
-
-=== "world.nether.blocks"
-    !!! summary "Description"
-        Blocks that will occasionally replace main block by random chance.
-        Blocks will replace only main-block and will try to create packs that
-        are set in their strings. Chance of spawning also is required.
-        
-        For materials first string must be MATERIAL, for entity: ENTITY.
-        
-        Entities spawned via generator are not protected from despawing.
-        Working only with 2 high mobs currently.
-
-    !!! example "Example"
-        ```yaml
-            blocks:
-                - MATERIAL:DIAMOND_ORE:100:5 
-        ```        
-        Means there is 100% chace of spawing diamonds where max amount in pack are 5 per each subchunk!
+        Allows setting main block that will be used for the nether world generation. Setting it to AIR will create void world. Ore veins (ancient debris, nether quartz, obsidian, glowstone and more) are placed on top of this by the vein populator.
 
 === "world.end.roof"
     !!! summary "Description"
@@ -131,25 +72,7 @@ You can find the latest config file: [config.yml](https://github.com/BentoBoxWor
 
 === "world.end.main-block"
     !!! summary "Description"
-        Allows setting main block that will be used for the end world generation. Setting it to AIR will create void world.
-
-=== "world.end.blocks"
-    !!! summary "Description"
-        Blocks that will occasionally replace main block by random chance.
-        Blocks will replace only main-block and will try to create packs that
-        are set in their strings. Chance of spawning also is required.
-        
-        For materials first string must be MATERIAL, for entity: ENTITY.
-        
-        Entities spawned via generator are not protected from despawing.
-        Working only with 2 high mobs currently.
-
-    !!! example "Example"
-        ```yaml
-            blocks:
-                - MATERIAL:DIAMOND_ORE:100:5 
-        ```        
-        Means there is 100% chace of spawing diamonds where max amount in pack are 5 per each subchunk!
+        Allows setting main block that will be used for the end world generation. Setting it to AIR will create void world. Ore veins are placed on top of this by the vein populator.
 
 ## Commands
 
@@ -199,6 +122,23 @@ Addon introduces 1 BentoBox Settings flag:
 ??? question "I have a bug, where should I report it?"
     Please add it to the list [here](https://github.com/BentoBoxWorld/CaveBlock/issues).
 
+
+## Changelog
+
+!!! warning "What's new in v1.21.0 — Breaking: world generation reworked"
+    **Released:** 2026-06-27
+
+    A major generation overhaul. CaveBlock now targets **Paper 1.21.11 on Java 21** and the **BentoBox 3.14 API**.
+
+    - 🔺 **Vanilla cave world generation.** The overworld delegates to Minecraft's own 1.18+ noise generator, so islands are carved through genuine cheese, spaghetti, lush, dripstone and deep-dark caves, complete with vanilla ores, decorations, structures (mineshafts, dungeons, trial chambers, amethyst geodes, ancient cities) and underground biomes. The sky is capped with stone so the world stays solid rock from bedrock to the roof.
+    - 💎 **Reworked Nether & End ore veins.** The Nether and End keep the fill-and-decorate approach with a new vein populator that places properly sized ore blobs (ancient debris, quartz, obsidian, glowstone and more) instead of single blocks.
+    - ⚙️ **Config cleanup.** World-generation settings were reworked and dead options removed — `generation-tries`, `use-new-material-generator`, the per-dimension `blocks` lists, the `natural-surface`/`natural-caves`/`natural-bedrock` toggles and the old `netherBlocks`/`endBlocks`/`debug` settings are gone. Back up your existing `config.yml` before letting the addon write the new defaults.
+    - 🔡 **MiniMessage locales.** All locale files were migrated from legacy colour codes to MiniMessage, and the height-limit message key was renamed to `caveblock.general.errors.cave-limit-reached`. Regenerate your locale files if you have customised them.
+    - 🧪 A full JUnit 5 + MockBukkit test suite was added to guard generation, height limits and addon lifecycle.
+
+    🔺 **World generation changed:** Newly generated overworld chunks now use vanilla noise caves instead of solid-fill carving. Already-generated chunks are untouched, but new terrain at the edges of your world will look different from older areas. Test on a copy first if this matters to you.
+
+    [Release v1.21.0](https://github.com/BentoBoxWorld/CaveBlock/releases/tag/1.21.0)
 
 ## Translations
 

--- a/docs/gamemodes/Poseidon/index.md
+++ b/docs/gamemodes/Poseidon/index.md
@@ -81,6 +81,17 @@ Commands can be found [here](Commands).
 
 Placeholders can be found [here](Placeholders).
 
+## Changelog
+
+??? note "What's new in v1.1.1"
+    **Released:** 2026-06-28
+
+    Bug-fix release — drop-in replacement, no config or locale changes.
+
+    - 🔺 🐛 **Fixed a server crash during world creation on Peaceful difficulty (Paper 26.2).** The Nether populator tried to spawn monsters (Drowned / Guardian / Elder Guardian), which is not allowed on Peaceful and crashed the chunk system. Monster spawns are now skipped on Peaceful and guarded defensively so world generation can never crash.
+
+    [Release v1.1.1](https://github.com/BentoBoxWorld/poseidon/releases/tag/1.1.1)
+
 ## Translations
 
 {{ translations("Poseidon") }}


### PR DESCRIPTION
## Summary

Documentation updates triggered by new releases detected since **2026-06-16**:

| Repo | Previous | New |
|---|---|---|
| BentoBox | 3.17.0 | 3.18.0, 3.18.1 |
| CaveBlock | — | 1.21.0 |
| MagicCobblestoneGenerator | — | 2.8.0 |
| Challenges | 1.6.1 | 1.7.0 |
| AOneBlock | 1.25.0 | 1.25.1 |
| Bank | 1.10.0 | 1.10.1 |
| InvSwitcher | 1.18.0 | 1.19.0, 1.19.1 |
| Limits | 1.28.2 | 1.28.3 |
| poseidon | — | 1.1.1 |

## Changes per repo

### BentoBox (3.17.0 → 3.18.1)
- Added `range removebonus` / `range purgebonus` admin commands to the Per-Game-Mode Admin Commands table (`About/AdminTools.md`)
- Added a Changelog section documenting MC 26.2 / Java 25 support, the new `dynmap` config toggles, admin range bonus management, and the 3.18.1 multi-line lore colour fix

### CaveBlock (→ 1.21.0)
- Rewrote the Configuration section for the new **vanilla cave world generation**: removed the now-deleted config options (`generation-tries`, `use-new-material-generator`, per-dimension `blocks` lists, `natural-*` toggles) and updated the `main-block` / Nether / End descriptions
- Added a breaking-change Changelog entry (world generation rework, config cleanup, MiniMessage locales, Paper 1.21.11 / Java 21 / BentoBox 3.14)

### MagicCobblestoneGenerator (→ 2.8.0)
- Documented the new **generator exhaustion** config (`exhaustion.limit` / `period` / `cooldown` / `notification-cooldown` + per-tier `exhaustion-limit`) and **per-block height ranges**
- Added two placeholders to `data/placeholders.csv` (`_generator_exhaustion_status`, `_exhausted_generator_names`)
- Added a breaking-change Changelog entry (MiniMessage + 13 new languages, BentoBox 3.14 / Java 21)

### Challenges (1.6.1 → 1.7.0)
- Added a *"What are team challenges?"* FAQ and a 1.7.0 Changelog entry

### AOneBlock, Bank, InvSwitcher, Limits, poseidon
- Added Changelog entries for the new bug-fix releases (poseidon gets its first Changelog section)

## Verification

- [x] `mkdocs build --strict` passes with zero warnings (with `GITHUB_TOKEN` set for the translation macros)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KEE62bDymknd5BhRmE4nvw