### PR TITLE
Document console form of admin team setowner

### DIFF
--- a/docs/BentoBox/ConcurrentIslands.md
+++ b/docs/BentoBox/ConcurrentIslands.md
@@ -36,6 +36,21 @@ As of BentoBox 3.16.0, this cap is enforced on both `/island team setowner` and 
 
 *NEW:* When a player transfers ownership they now automatically leave the team.
 
+#### Transferring from the console (admin)
+
+Run in-game, `/[gamemode] admin team setowner <player>` transfers the island the admin is **standing on** and asks for confirmation.
+
+Since BentoBox 3.18.0 you can also name the island's current owner:
+
+`/[gamemode] admin team setowner <newOwner> <islandOwner>`
+
+Naming the island this way means the admin no longer has to stand on it, so the command works from the **server console** — and therefore from automation such as Skript. When run from the console the confirmation prompt is skipped, because the console cannot answer one.
+
+- `<newOwner>` — the player who becomes the owner. They do **not** need to be online or standing anywhere; any player BentoBox already knows (or a raw UUID) works.
+- `<islandOwner>` — the current owner, used only to identify **which** island to transfer. The command transfers the island that player actually owns; if their active island is a team island belonging to someone else, the transfer is refused. If they own more than one island, their **primary/active** island is used.
+
+The concurrent-island cap still applies: if `<newOwner>` is already at their maximum number of islands the transfer is refused, and you must raise their `[gamemode].island.number.<n>` permission (or the world's `concurrent-islands` setting) first. As with the in-game form, the previous owner is demoted to Member of the island rather than removed.
+
 ### Teams
 
 - Teams are island-based and teams do not span islands.

--- a/docs/gamemodes/BSkyBlock/Commands.md
+++ b/docs/gamemodes/BSkyBlock/Commands.md
@@ -126,8 +126,8 @@
 <td align='left'>bskyblock.admin.blueprint</td>
 </tr>
 <tr>
-<td align='left'><b>/bsbadmin setowner <player></b></td>
-<td align='left'>transfers island ownership to the player</td>
+<td align='left'><b>/bsbadmin setowner <player> [island owner]</b></td>
+<td align='left'>transfers island ownership to the player; name the current owner to run it from the console</td>
 <td align='left'>bskyblock.mod.team</td>
 </tr>
 <tr>

--- a/docs/gamemodes/Boxed/Commands.md
+++ b/docs/gamemodes/Boxed/Commands.md
@@ -124,8 +124,8 @@ All the commands are the same as other game modes, like BSkyBlock.
 <td align='left'></td>
 </tr>
 <tr>
-<td align='left'><b>/boxadmin setowner <player></b></td>
-<td align='left'>transfers island ownership to the player</td>
+<td align='left'><b>/boxadmin setowner <player> [island owner]</b></td>
+<td align='left'>transfers island ownership to the player; name the current owner to run it from the console</td>
 <td align='left'>boxed.admin.register</td>
 </tr>
 <tr>

--- a/docs/gamemodes/Poseidon/Commands.md
+++ b/docs/gamemodes/Poseidon/Commands.md
@@ -116,8 +116,8 @@
 <td align='left'>poseidon.admin.blueprint</td>
 </tr>
 <tr>
-<td align='left'><b>/padmin setowner <player></b></td>
-<td align='left'>transfers realm ownership to the player</td>
+<td align='left'><b>/padmin setowner <player> [realm owner]</b></td>
+<td align='left'>transfers realm ownership to the player; name the current owner to run it from the console</td>
 <td align='left'>poseidon.mod.team</td>
 </tr>
 <tr>

--- a/docs/gamemodes/SkyGrid/Commands.md
+++ b/docs/gamemodes/SkyGrid/Commands.md
@@ -98,8 +98,8 @@
 <td align='left'>skygrid.admin.blueprint</td>
 </tr>
 <tr>
-<td align='left'><b>/sgadmin setowner <player></b></td>
-<td align='left'>transfers area ownership to the player</td>
+<td align='left'><b>/sgadmin setowner <player> [area owner]</b></td>
+<td align='left'>transfers area ownership to the player; name the current owner to run it from the console</td>
 <td align='left'>skygrid.mod.team</td>
 </tr>
 <tr>

--- a/docs/gamemodes/StrangerRealms/Commands.md
+++ b/docs/gamemodes/StrangerRealms/Commands.md
@@ -270,8 +270,8 @@ tr>
 <td align='left'>strangerrealms.admin.blueprint</td>
 </tr>
 <tr>
-<td align='left'><b>/stranger setowner <player></b></td>
-<td align='left'>transfers claim ownership to the player</td>
+<td align='left'><b>/stranger setowner <player> [claim owner]</b></td>
+<td align='left'>transfers claim ownership to the player; name the current owner to run it from the console</td>
 <td align='left'>strangerrealms.mod.team</td>
 </tr>
 <tr>


### PR DESCRIPTION
Documents the new optional `[island owner]` argument on `admin team setowner`, added in BentoBox 3.18.0 (BentoBoxWorld/BentoBox#3003).

## What

`/[gamemode] admin team setowner <newOwner> <islandOwner>` names the island by its current owner, so the command no longer requires the admin to stand on it — it now runs from the **console** and therefore from automation such as Skript. Console execution skips the confirmation prompt.

## Changes

- **`ConcurrentIslands.md`** — new "Transferring from the console (admin)" subsection under *Island transfer*, covering the two-arg form, the primary/active island resolution, the ownership requirement (a team island the named player only belongs to is refused), and the still-enforced concurrent-island cap.
- **Gamemode command tables** — added the `[island owner]` argument and a short console note to each admin `setowner` row: BSkyBlock, Boxed, Poseidon, SkyGrid, StrangerRealms (each keeps its own noun — island/area/claim/realm).

## Notes

The gamemode `Commands.md` tables are generated from the plugin's locale strings, and the corresponding `parameters`/`description` keys were already updated in the code PR, so these rows will also regenerate on the next docs sync — this just makes them current now.

Depends on / documents: BentoBoxWorld/BentoBox#3003

🤖 Generated with [Claude Code](https://claude.com/claude-code)