### PR TITLE
docs: update documentation for releases 2026-07-08

### DIFF
--- a/data/flags.csv
+++ b/data/flags.csv
@@ -8,6 +8,7 @@ BentoBox,AXOLOTL_SCOOPING,"Axolotl Scooping",AXOLOTL_BUCKET,"Allow scooping of a
 BentoBox,BARREL,"Barrels",BARREL,"Toggle barrel interaction",PROTECTION,ADVANCED,MEMBER_RANK,VISITOR_RANK,OWNER_RANK
 BentoBox,BEACON,"Beacons",BEACON,"Toggle interaction",PROTECTION,EXPERT,MEMBER_RANK,VISITOR_RANK,OWNER_RANK
 BentoBox,BED,"Beds",RED_BED,"Toggle interaction",PROTECTION,EXPERT,MEMBER_RANK,VISITOR_RANK,OWNER_RANK
+BentoBox,BED_ANCHOR_RESPAWN,"Bed/anchor respawn",RED_BED,"Respawn players at a valid bed or respawn anchor if it is on an island they are a member of.",WORLD_SETTING,EXPERT,true,,
 BentoBox,BLOCK_EXPLODE_DAMAGE,"Block explode damage",TNT_MINECART,"Allow Bed & Respawn Anchors to break blocks and damage entities.",SETTING,ADVANCED,false,,
 BentoBox,BOAT,"Boats",OAK_BOAT,"Toggle placing, breaking and entering into boats.",PROTECTION,BASIC,MEMBER_RANK,VISITOR_RANK,OWNER_RANK
 BentoBox,BREAK_BLOCKS,"Break blocks",STONE_PICKAXE,"Toggle breaking",PROTECTION,BASIC,MEMBER_RANK,VISITOR_RANK,OWNER_RANK
@@ -54,6 +55,7 @@ BentoBox,FIRE_BURNING,"Fire burning",CHARCOAL,"Toggle whether fire can burn bloc
 BentoBox,FIRE_EXTINGUISH,"Fire extinguish",POTION,"Toggle extinguishing fires",PROTECTION,EXPERT,MEMBER_RANK,VISITOR_RANK,OWNER_RANK
 BentoBox,FIRE_IGNITE,"Fire ignition",FLINT_AND_STEEL,"Toggle whether fire can be ignited by non-player means or not.",SETTING,ADVANCED,true,,
 BentoBox,FIRE_SPREAD,"Fire spread",FIREWORK_STAR,"Toggle whether fire can spread to nearby blocks or not.",SETTING,ADVANCED,true,,
+BentoBox,FISHING,"Fishing",FISHING_ROD,"Allow fishing with a fishing rod. Prevents fishing into protected areas from outside the island.",PROTECTION,EXPERT,VISITOR_RANK,VISITOR_RANK,OWNER_RANK
 BentoBox,FISH_SCOOPING,"Fish Scooping",TROPICAL_FISH_BUCKET,"Allow scooping of fishes using a bucket",PROTECTION,EXPERT,MEMBER_RANK,VISITOR_RANK,OWNER_RANK
 BentoBox,FLINT_AND_STEEL,"Flint and steel",FLINT_AND_STEEL,"Allow players to ignite fires or campfires using flint and steel or fire charges.",PROTECTION,ADVANCED,MEMBER_RANK,VISITOR_RANK,OWNER_RANK
 BentoBox,FLOWER_POT,"Flower pots",FLOWER_POT,"Toggle flower pot interaction",PROTECTION,ADVANCED,MEMBER_RANK,VISITOR_RANK,OWNER_RANK

--- a/data/release-tracker.json
+++ b/data/release-tracker.json
@@ -1,9 +1,9 @@
 {
-  "last_run": "2026-07-03T00:00:00Z",
+  "last_run": "2026-07-08T02:07:59Z",
   "repos": {
     "BentoBox": {
-      "last_checked": "2026-07-03T00:00:00Z",
-      "last_release": "3.18.1",
+      "last_checked": "2026-07-08T02:07:59Z",
+      "last_release": "3.19.0",
       "doc_path": "BentoBox/",
       "category": "core"
     },
@@ -14,7 +14,7 @@
       "category": "gamemode"
     },
     "AOneBlock": {
-      "last_checked": "2026-07-03T00:00:00Z",
+      "last_checked": "2026-07-08T02:07:59Z",
       "last_release": "1.25.1",
       "doc_path": "gamemodes/AOneBlock/index.md",
       "category": "gamemode"
@@ -32,8 +32,8 @@
       "category": "gamemode"
     },
     "CaveBlock": {
-      "last_checked": "2026-07-03T00:00:00Z",
-      "last_release": "1.21.0",
+      "last_checked": "2026-07-08T02:07:59Z",
+      "last_release": "1.23.0",
       "doc_path": "gamemodes/CaveBlock/index.md",
       "category": "gamemode"
     },
@@ -152,14 +152,14 @@
       "category": "addon"
     },
     "Limits": {
-      "last_checked": "2026-07-03T00:00:00Z",
-      "last_release": "1.28.3",
+      "last_checked": "2026-07-08T02:07:59Z",
+      "last_release": "1.28.4",
       "doc_path": "addons/Limits/index.md",
       "category": "addon"
     },
     "MagicCobblestoneGenerator": {
-      "last_checked": "2026-07-03T00:00:00Z",
-      "last_release": "2.8.0",
+      "last_checked": "2026-07-08T02:07:59Z",
+      "last_release": "2.9.0",
       "doc_path": "addons/MagicCobblestoneGenerator/index.md",
       "category": "addon"
     },

--- a/docs/BentoBox/About/AdminTools.md
+++ b/docs/BentoBox/About/AdminTools.md
@@ -33,6 +33,9 @@ Each game mode has its own admin command. For BSkyBlock it's `/bsb`, for AcidIsl
 |---|---|
 | `/[admin] info <player>` | Shows full details of a player's island |
 | `/[admin] delete <player>` | Deletes a player's island |
+| `/[admin] delete` | *(3.19.0)* With no player argument, soft-deletes the island you are **standing on** after confirmation (refused if it still has a team) |
+| `/[admin] undelete` | *(3.19.0)* Clears the pending-deletion status of the island you are **standing on**, leaving it unowned, before its region files are purged |
+| `/[admin] register <player>` | Registers an unowned island to a player. On an island pending deletion this now shows a confirmation prompt and cancels the deletion instead of refusing |
 | `/[admin] setrange <player> <range>` | Changes a player's island protection range |
 | `/[admin] range removebonus <player> [id]` | Removes all bonus protection ranges from a single island, or just those for a given id |
 | `/[admin] range purgebonus <id>` | Removes a bonus range id from **every** island in the world — ideal after uninstalling an addon that granted bonus ranges. The scan runs asynchronously so it won't freeze large servers |
@@ -102,7 +105,23 @@ This reloads BentoBox and all addons, including locales. Note that some changes 
 
 ## Changelog
 
-!!! warning "What's new in v3.18.0 — Minecraft 26.2 support requires Java 25 (server)"
+!!! warning "What's new in v3.19.0 — bed/anchor respawns now honored"
+    **Released:** 2026-07-08
+
+    Compatibility: Paper Minecraft 1.21.5 – 26.2, Java 25+.
+
+    - 🔡 **New `FISHING` protection flag.** Stops players fishing into protected areas from outside the island (the flag checks the hook's location). Defaults to visitor rank, so nothing changes until you raise it.
+    - 🔺 **Bed & respawn-anchor spawns are now honored.** Dying on an island now respawns you at your bed or charged respawn anchor when it's on an island you're a member of. Controlled by the new `BED_ANCHOR_RESPAWN` world setting (**enabled by default**); economy-sensitive servers that want the old "always respawn at island home" behaviour should disable it.
+    - 🐛 **End exit portal no longer dumps you at world spawn.** Jumping through the end exit portal now routes you to your safe island home on multi-gamemode servers.
+    - 🐛 **Item frames and paintings survive blueprints.** Frames keep their facing and contents, and paintings restore their artwork, instead of popping off or facing the wrong way.
+    - 🔡 **Recover islands pending deletion.** New `/[admin] undelete`, a stand-on `/[admin] delete` (no player argument), and a confirmation prompt on `/[admin] register` can now rescue soft-deleted islands before their region files are purged (see the Per-Game-Mode Admin Commands table above).
+    - ⚙️ **BlueMap island layer survives reloads.** Owner pins and area boxes no longer vanish after `/bluemap reload`. A new `bluemap` section in `config.yml` adds `island-markers` and `island-areas` toggles (both default `true`), mirroring the Dynmap toggles, plus marker customization.
+    - ⚙️ **Configurable team panel button icons + member/prospect text.** The STATUS, RANK-filter and INVITE buttons in the team panel now honour the `icon:` set in `team_panel.yml`, and the member/prospect button name and description are now driven by locale keys. Defaults reproduce the previous appearance exactly.
+    - ⚡ **Settings-GUI click spam no longer spikes MSPT.** Spam-clicking `/is settings` dropped from ~30–40 MSPT to negligible via in-place panel refresh and a translation cache.
+
+    [Release v3.19.0](https://github.com/BentoBoxWorld/BentoBox/releases/tag/3.19.0)
+
+??? warning "What's new in v3.18.0 — Minecraft 26.2 support requires Java 25 (server)"
     **Released:** 2026-06-27
 
     - 🔺 **Minecraft 26.2 support + Java 25.** BentoBox now runs on the Minecraft 26.x line (26.2 supported at runtime) and the build has migrated to the Java 25 toolchain. **Your server must run on a Java 25-capable Paper build for the 26.x line.** Already-built addon jars keep working unchanged — only addon *developers* recompiling against this release need to move their own build to Java 25. Compatibility: Paper Minecraft 1.21.5 – 26.2, Java 25+.

--- a/docs/BentoBox/About/IslandManagement.md
+++ b/docs/BentoBox/About/IslandManagement.md
@@ -47,6 +47,14 @@ This removes the island from the database and marks the area for cleanup. The pl
 
 As of BentoBox 3.16.1, the actual region files are reaped on the next housekeeping sweep (default: 24 h) rather than on demand. If the island shares a region file with other live islands, the deleted area stays in place until that region is clear. To force immediate cleanup, run `/bbox admin purge deleted` after the delete — it will only remove blocks if the region file no longer hosts any live island. For surgical block removal in a shared region, use WorldEdit or remove the blocks manually.
 
+### Deleting and recovering the island you are standing on
+
+Since BentoBox 3.19.0, a delete can be triggered — and reversed — without naming a player, as long as you are standing on the island. Because the region files are only reaped on the next housekeeping sweep, a soft-deleted island can be rescued right up until that purge runs:
+
+- `/[admin_command] delete` (no player argument) soft-deletes the island you are standing on after a confirmation prompt. It is refused if the island still has a team.
+- `/[admin_command] undelete` clears the pending-deletion status of the island you are standing on, leaving it unowned.
+- `/[admin_command] register <player>` on an island pending deletion now shows a confirmation prompt; confirming registers the island to that player and cancels its deletion.
+
 ## Inactive Island Cleanup
 
 If players abandon the server, their islands stay in the world. BentoBox does not automatically delete inactive islands, but the **deletion flag** and external tools can be used to manage this. Many server admins handle this by setting a reset limit and reviewing inactive players periodically.

--- a/docs/addons/Limits/index.md
+++ b/docs/addons/Limits/index.md
@@ -145,6 +145,16 @@ Some items cannot be limited (right now). The reasons are usually because there 
 
 ## Changelog
 
+??? note "What's new in v1.28.4"
+    **Released:** 2026-07-06
+
+    Maintenance release focused on keeping entity counts accurate and reliably persisted. No config or locale changes are required.
+
+    - 🐛 **Entity counts no longer drift above reality.** Under some spawn/removal sequences the tracked entity count could climb above the number of entities actually on the island, eventually blocking spawns that should have been allowed. Counts now stay in sync with the real island population. [[#273](https://github.com/BentoBoxWorld/Limits/pull/273)]
+    - 🐛 **Entity count persistence centralized.** All entity count mutations now flow through `BlockLimitsListener`, so changes are enrolled in the normal batch-save cycle instead of only being written on addon disable. This prevents count loss on an unclean shutdown or crash. [[#274](https://github.com/BentoBoxWorld/Limits/pull/274)]
+
+    [Release v1.28.4](https://github.com/BentoBoxWorld/Limits/releases/tag/1.28.4)
+
 ??? note "What's new in v1.28.3"
     **Released:** 2026-06-29
 

--- a/docs/addons/MagicCobblestoneGenerator/index.md
+++ b/docs/addons/MagicCobblestoneGenerator/index.md
@@ -149,6 +149,25 @@ Since **2.8.0** generators can be capped so they only produce a set number of bl
 
 Also since **2.8.0**, generators — and individual blocks within a generator — can be limited to a minimum and maximum Y level, so different materials are produced at different heights. New GUI buttons let admins set and clear the range, and the generator lore shows players where each generator operates. Legacy templates without a height range remain fully compatible.
 
+### Unlock progression and requirements
+
+Since **2.9.0** generators can be gated behind richer requirements so you can design proper unlock trees instead of a flat list of tiers. All of these are configured from the generator edit panel in the Admin GUI:
+
+- **Prerequisite generators** — require one or more other generators to be unlocked first, building multi-step progressions.
+- **AOneBlock phase requirement** — on AOneBlock game modes, gate a generator behind a specific island phase, so tiers unlock as the island advances.
+- **OneBlock block-count requirement** — gate a generator behind the number of blocks broken on a OneBlock island.
+- **Activate on unlock** — a per-generator option that activates a generator automatically the moment it is unlocked, saving players a trip to the GUI.
+- **Purchase confirmation** — optionally require an explicit confirmation before any money is taken when buying a generator, preventing accidental purchases.
+
+=== "lose-tiers-on-level-loss"
+    !!! summary "Description"
+        *Added in 2.9.0.* Restores the pre-2.0.0 behaviour where a generator unlocked by island level is re-locked if the island level later drops below its requirement. Purchased tiers are always kept — only free, level-unlocked tiers are re-locked. Written to `config.yml` automatically on first load after upgrading.
+
+        Default: `false`
+
+!!! warning "Permission-gated generators are now revoked"
+    Since **2.9.0**, a generator unlocked via permission is re-checked and **revoked** from an island's unlocked and active lists when the current (online) owner no longer holds the required permission — for example after an ownership transfer. Purchased tiers are preserved, so access returns if the permission is regained; offline owners are left untouched. Previously such a grant was permanent.
+
 ## Commands
 
 !!! tip
@@ -169,6 +188,7 @@ Also since **2.8.0**, generators — and individual blocks within a generator �
     - `/[admin_command] generator database import <file>`: Ability to import database exported <file>.
     - `/[admin_command] generator database export <file>`: Ability to export database into <file> saved in `/plugins/BentoBox/addons/MagicCobblestoneGenerator/` folder.
     - `/[admin_command] generator why <player>`: A debugging command that allows finding issues with generators for each player.
+    - `/[admin_command] generator reset <player>`: Resets a player's island generator data — unlocked, purchased, and active generators — after a confirmation prompt. *(Added in 2.9.0.)*
 
 ## Permissions
 
@@ -299,7 +319,24 @@ Also since **2.8.0**, generators — and individual blocks within a generator �
 
 ## Changelog
 
-!!! warning "What's new in v2.8.0 — requires BentoBox 3.14.0 / Java 21"
+??? warning "What's new in v2.9.0 — permission-gated generators now revoked"
+    **Released:** 2026-07-08
+
+    Adds richer unlock progression and several admin/API improvements.
+
+    - 🔒 **Prerequisite generators.** Gate a generator behind one or more others so tiers unlock in a designed progression. Configured through a new admin GUI selector. Fixes [#88](https://github.com/BentoBoxWorld/MagicCobblestoneGenerator/issues/88).
+    - 🧱 **OneBlock / AOneBlock gating.** Require a specific AOneBlock phase, or a number of blocks broken on a OneBlock island, before a generator becomes available. Fixes [#121](https://github.com/BentoBoxWorld/MagicCobblestoneGenerator/issues/121), [#117](https://github.com/BentoBoxWorld/MagicCobblestoneGenerator/issues/117).
+    - ⚙️ **Re-lock level tiers on level loss.** A new `lose-tiers-on-level-loss` setting (default `false`) re-locks level-unlocked generators if an island's level drops. Purchased tiers are always kept. Fixes [#118](https://github.com/BentoBoxWorld/MagicCobblestoneGenerator/issues/118).
+    - ✨ **Activate on unlock.** Generators can now activate automatically the moment they are unlocked. Fixes [#106](https://github.com/BentoBoxWorld/MagicCobblestoneGenerator/issues/106).
+    - 💰 **Purchase confirmation.** Optionally ask players to confirm before money is taken for a generator. Fixes [#109](https://github.com/BentoBoxWorld/MagicCobblestoneGenerator/issues/109).
+    - 🛠️ **Admin data reset.** A new `/[admin_command] generator reset <player>` command resets a player's unlocked, purchased, and active generators after a confirmation prompt. Fixes [#149](https://github.com/BentoBoxWorld/MagicCobblestoneGenerator/issues/149).
+    - 🔌 **New cancellable API events** `GeneratorPreBuyEvent` and `GeneratorTreasureDropEvent` for other addons to hook into (see the API section below).
+    - 🔺 **Behaviour change:** permission-gated generators are now **revoked** when an island's online owner no longer holds the required permission — for example after an ownership transfer. Purchased tiers are preserved, so access returns if the permission is regained.
+    - 🔡 **Locale note:** new `en-US.yml` keys were added for the prerequisite selector, activate-on-unlock, purchase confirmation, the admin reset command, and OneBlock/AOneBlock requirement messages. Regenerate or update your locale files to pick up the new strings.
+
+    [Release v2.9.0](https://github.com/BentoBoxWorld/MagicCobblestoneGenerator/releases/tag/2.9.0)
+
+??? warning "What's new in v2.8.0 — requires BentoBox 3.14.0 / Java 21"
     **Released:** 2026-07-03
 
     - ⚙️ **Generator exhaustion.** Optionally rate-limit how many blocks a generator produces per period, with a cooldown once the limit is hit. Configurable globally (`exhaustion.*` in `config.yml`) and per generator tier (`exhaustion-limit` in the template). Opt-in and disabled by default. See the Configuration section above.
@@ -424,6 +461,67 @@ The JavaDocs for MagicCobblestoneGenerator can be found [here](https://ci.codemc
 
             String generator = event.getGenerator();
             String generatorID = event.getGeneratorID();
+        }
+        ```
+
+=== "GeneratorPreBuyEvent"
+    !!! summary "Description"
+        Event that is triggered **before** a generator is purchased, allowing the buy to be cancelled or inspected. Extends the shared `GeneratorEvent` base.
+        This event is cancellable.
+
+        Since 2.9.0 version.
+
+        Link to the class: [GeneratorPreBuyEvent](https://github.com/BentoBoxWorld/MagicCobblestoneGenerator/blob/develop/src/main/java/world/bentobox/magiccobblestonegenerator/events/GeneratorPreBuyEvent.java)
+
+    !!! question "Variables"
+        - `String islandUUID` - the targeted island id.
+        - `UUID targetPlayer` - id of the player who is buying the generator.
+        - `String generator` - the name of the generator being bought.
+        - `String generatorID` - the id of the generator being bought.
+
+        
+    !!! example "Code example"
+        ```java
+        @EventHandler(priority = EventPriority.LOW)
+        public void onGeneratorPreBuy(GeneratorPreBuyEvent event) {
+            UUID user = event.getTargetPlayer();
+            String island = event.getIslandUUID();
+            String generatorID = event.getGeneratorID();
+
+            // Veto the purchase if needed
+            if (someCondition) {
+                event.setCancelled(true);
+            }
+        }
+        ```
+
+=== "GeneratorTreasureDropEvent"
+    !!! summary "Description"
+        Event that is triggered when a treasure is about to drop from a generator, allowing the drop to be cancelled or altered. Extends the shared `GeneratorEvent` base.
+        This event is cancellable.
+
+        Since 2.9.0 version.
+
+        Link to the class: [GeneratorTreasureDropEvent](https://github.com/BentoBoxWorld/MagicCobblestoneGenerator/blob/develop/src/main/java/world/bentobox/magiccobblestonegenerator/events/GeneratorTreasureDropEvent.java)
+
+    !!! question "Variables"
+        - `String islandUUID` - the targeted island id.
+        - `UUID targetPlayer` - id of the player the treasure is dropping for.
+        - `String generator` - the name of the generator dropping the treasure.
+        - `String generatorID` - the id of the generator dropping the treasure.
+        - `Location location` - the location the treasure is about to drop at.
+        - `ItemStack itemStack` - the treasure item about to drop (can be modified).
+
+        
+    !!! example "Code example"
+        ```java
+        @EventHandler(priority = EventPriority.LOW)
+        public void onTreasureDrop(GeneratorTreasureDropEvent event) {
+            Location location = event.getLocation();
+            ItemStack treasure = event.getItemStack();
+
+            // Cancel the drop or swap the item
+            event.setCancelled(true);
         }
         ```
 

--- a/docs/gamemodes/CaveBlock/index.md
+++ b/docs/gamemodes/CaveBlock/index.md
@@ -38,6 +38,43 @@ You can find the latest config file: [config.yml](https://github.com/BentoBoxWor
 
         Allows to create some fresh air above your cave.
 
+=== "world.structures"
+    !!! summary "Description"
+        *Added in 1.23.0.* A map of vanilla structures that may generate in the **overworld** cave world. Set a structure to `false` to stop it generating; structures not listed here generate as normal. Use the vanilla structure key, for example `ancient_city`, `trial_chambers`, `mineshaft`, `mineshaft_mesa`, `stronghold`, `mansion`, `monument`, `pillager_outpost`, `ruined_portal`, `trail_ruins`, `village_plains`, `desert_pyramid`, `jungle_pyramid`, `igloo`, `swamp_hut`.
+
+        Large structures like Ancient Cities and Trial Chambers can fill or unbalance a solid cave world, so they are **disabled by default**. Only affects newly generated overworld chunks.
+
+        Default:
+        ```yaml
+        structures:
+          ancient_city: false
+          trial_chambers: false
+          mansion: false
+          mineshaft: true
+          stronghold: true
+        ```
+
+=== "world.overworld-cave-fill"
+    !!! summary "Description"
+        *Added in 1.23.0.* Overworld cave density. Vanilla generates a dense 1.18+ cave network (cheese and spaghetti caves) which, on a solid cave world, can feel like "nothing but passageways". This re-solidifies a fraction of that cave air after generation using a low-frequency noise field, so whole regions close up into separate chambers rather than punching random single holes.
+
+        - `0.0` keeps every vanilla cave (densest, the original behaviour).
+        - `1.0` fills nearly all caves (almost solid).
+        - Try `0.4` – `0.6` to thin them out.
+
+        Underground biomes, ores, decorations and structures are kept either way. Only affects newly generated chunks.
+
+        Default: `0.0`
+
+=== "world.overworld-carvers"
+    !!! summary "Description"
+        *Added in 1.23.0.* Generate vanilla carver caves (big ravines and long round tunnels) in the overworld. These stack on top of the noise caves. Set to `false` to remove the ravines and wide tunnels while keeping the noise caves.
+
+        !!! warning
+            BentoBox does not support changing this value mid-game. If you need to change it, do a full reset of your worlds and databases.
+
+        Default: `true`
+
 === "world.normal.roof"
     !!! summary "Description"
         Allows toggling if overworld top block should be bedrock block. Otherwise, it will be made of stone.
@@ -125,7 +162,35 @@ Addon introduces 1 BentoBox Settings flag:
 
 ## Changelog
 
-!!! warning "What's new in v1.21.0 — Breaking: world generation reworked"
+??? note "What's new in v1.23.0"
+    **Released:** 2026-07-07
+
+    Hands admins direct control over what fills the overworld cave world, building on the 1.22.0 generation work.
+
+    - ⚙️ **Configurable overworld structures.** A new `structures:` section in `config.yml` toggles individual vanilla structures (Ancient Cities, Trial Chambers, Mansions, Mineshafts, Strongholds and more). The largest, world-filling structures are disabled by default. Fixes [#112](https://github.com/BentoBoxWorld/CaveBlock/issues/112).
+    - ⚙️ **Overworld cave density control.** A new `overworld-cave-fill` setting (`0.0`–`1.0`, default `0.0`) re-solidifies a fraction of the dense vanilla cave network so worlds feel less like endless passageways, while keeping biomes, ores, decorations and structures intact. Fixes [#111](https://github.com/BentoBoxWorld/CaveBlock/issues/111).
+    - ⚙️ **Carver cave toggle.** A new `overworld-carvers` setting (default `true`) removes vanilla ravines and wide tunnels while keeping the noise caves. This one cannot be changed mid-game.
+
+    New options are written to `config.yml` automatically on first run and only affect **newly generated** chunks; defaults preserve the 1.22.0 behaviour, except that the largest structures are now off by default. See the Configuration section above.
+
+    [Release v1.23.0](https://github.com/BentoBoxWorld/CaveBlock/releases/tag/1.23.0)
+
+??? warning "What's new in v1.22.0 — Nether & End generation reworked"
+    **Released:** 2026-07-06
+
+    Rebuilds how the **Nether** and **The End** are generated. Previously both dimensions were a solid block of rock peppered with random single blocks — including stray floating fire that caused lag — and had no real caves.
+
+    - 🔺 **Nether & End generation overhaul.** Both dimensions are now filled solid and carved by a 3D noise cave generator into connected tunnels and chambers, with a solid margin against the floor and roof.
+    - 🌋 **Nether lava sea.** The lowest cave voids fill with lava rather than open air; the floor and roof stay solid so the world stays enclosed.
+    - 🗺️ **Natural Nether biomes.** The five Nether biomes are shared into natural, roughly equal-area regions, so several biomes appear within a single island.
+    - 🌿 **Biome-aware decorations.** Crimson/warped nylium, roots, fungi and vines; soul sand valleys with soul fire and bones; basalt deltas with columns and magma fires; glowstone ceiling patches; end rods and chorus in The End.
+    - ⚡ **No more laggy floating fire.** Fire is now sparse and grounded on netherrack/magma.
+
+    🔺 **World generation changed:** The new generator only affects **newly generated** chunks. Existing Nether/End chunks keep the old look, so you may see a seam where old meets new. Regenerate those dimensions (or start fresh worlds) if you want a consistent look.
+
+    [Release v1.22.0](https://github.com/BentoBoxWorld/CaveBlock/releases/tag/1.22.0)
+
+??? warning "What's new in v1.21.0 — Breaking: world generation reworked"
     **Released:** 2026-06-27
 
     A major generation overhaul. CaveBlock now targets **Paper 1.21.11 on Java 21** and the **BentoBox 3.14 API**.


### PR DESCRIPTION
## Summary

Documentation updates triggered by new releases detected since 2026-07-03:

| Repo | Previous | New |
|---|---|---|
| BentoBox | 3.18.1 | 3.19.0 |
| CaveBlock | 1.21.0 | 1.23.0 |
| Limits | 1.28.3 | 1.28.4 |
| MagicCobblestoneGenerator | 2.8.0 | 2.9.0 |

## Changes per repo

### BentoBox (3.18.1 → 3.19.0)
- Added the `FISHING` protection flag and the `BED_ANCHOR_RESPAWN` world setting to `data/flags.csv` (auto-rendered on the Flags page).
- Documented the new island-recovery admin commands (`/[admin] undelete`, stand-on `/[admin] delete`, and the confirmation prompt on `/[admin] register`) in the AdminTools command table and a new subsection of IslandManagement.
- Added a "What's new in v3.19.0" changelog entry covering bed/anchor respawns, the end-portal fix, blueprint item-frame/painting fixes, BlueMap toggles, configurable team-panel buttons, and the settings-GUI performance work.

### CaveBlock (1.21.0 → 1.23.0)
- Documented the new overworld generation config options `structures`, `overworld-cave-fill`, and `overworld-carvers` (1.23.0).
- Added "What's new" changelog entries for the 1.22.0 Nether/End generation overhaul and the 1.23.0 structure/density controls.

### Limits (1.28.3 → 1.28.4)
- Added a "What's new in v1.28.4" changelog entry for the entity-count accuracy and persistence bug fixes. No config/locale changes.

### MagicCobblestoneGenerator (2.8.0 → 2.9.0)
- Documented the new unlock-progression requirements (prerequisites, AOneBlock phase, OneBlock block-count, activate-on-unlock, purchase confirmation) and the `lose-tiers-on-level-loss` config setting.
- Added the `/[admin_command] generator reset <player>` command and the two new cancellable API events `GeneratorPreBuyEvent` and `GeneratorTreasureDropEvent`.
- Added a "What's new in v2.9.0" changelog entry, including the permission-gated-generator revocation behaviour change.

_(AOneBlock 1.25.1 was re-published after the last run but is already documented, so only its tracker entry was refreshed.)_

## Verification

- [x] `mkdocs build --strict` passes with zero warnings (with `GITHUB_TOKEN` set so the `translations()` macro isn't rate-limited)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014DXJ2DZBPHknqxuqK6zQfB