### PR TITLE
docs: document Limits 1.29.0 and CaveBlock 1.23.1

### DIFF
--- a/data/placeholders.csv
+++ b/data/placeholders.csv
@@ -119,6 +119,10 @@ MagicCobblestoneGenerator,[gamemode]_magiccobblestonegenerator_generator_exhaust
 MagicCobblestoneGenerator,[gamemode]_magiccobblestonegenerator_exhausted_generator_names,List of the player island's generators that are currently on exhaustion cooldown separated with comma,2.8.0
 Limits,Limits_[gamemode]_island_[material]_count,Current count of material (lower cased) on the island,1.17.2
 Limits,Limits_[gamemode]_island_[material]_limit,The limit of material (lower cased) for the island,1.17.2
+Limits,Limits_[gamemode]_island_reached_limits,"Comma-separated list of every limited block, entity, and entity group that is at or over its limit across all dimensions",1.29.0
+Limits,Limits_[gamemode]_island_reached_limits_overworld,Reached limits in the overworld only,1.29.0
+Limits,Limits_[gamemode]_island_reached_limits_nether,Reached limits in the nether only,1.29.0
+Limits,Limits_[gamemode]_island_reached_limits_end,Reached limits in the end only,1.29.0
 TopBlock,aoneblock_island_player_name_top_<number>,Island owner's name at the `<number>` position, 1.0.1
 TopBlock,aoneblock_island_member_names_top_<number>,Name of island team members at the `<number>` position, 1.0.1
 TopBlock,aoneblock_island_phase_name_top_<number>,Name of the phase they have reached at the `<number>` position, 1.0.1

--- a/data/release-tracker.json
+++ b/data/release-tracker.json
@@ -1,5 +1,5 @@
 {
-  "last_run": "2026-07-08T02:07:59Z",
+  "last_run": "2026-07-11T00:00:00Z",
   "repos": {
     "BentoBox": {
       "last_checked": "2026-07-08T02:07:59Z",
@@ -32,8 +32,8 @@
       "category": "gamemode"
     },
     "CaveBlock": {
-      "last_checked": "2026-07-08T02:07:59Z",
-      "last_release": "1.23.0",
+      "last_checked": "2026-07-11T00:00:00Z",
+      "last_release": "1.23.1",
       "doc_path": "gamemodes/CaveBlock/index.md",
       "category": "gamemode"
     },
@@ -152,8 +152,8 @@
       "category": "addon"
     },
     "Limits": {
-      "last_checked": "2026-07-08T02:07:59Z",
-      "last_release": "1.28.4",
+      "last_checked": "2026-07-11T00:00:00Z",
+      "last_release": "1.29.0",
       "doc_path": "addons/Limits/index.md",
       "category": "addon"
     },

--- a/docs/addons/Limits/index.md
+++ b/docs/addons/Limits/index.md
@@ -26,10 +26,15 @@ The config.yml has the following sections:
 * blocklimits
 * blocklimits-nether
 * blocklimits-end
+* blockgrouplimits *(1.29.0+)*
+* blockgrouplimits-nether / blockgrouplimits-end *(1.29.0+)*
 * worlds
 * entitylimits
 * entitylimits-nether
 * entitylimits-end
+* entitygrouplimits
+
+It also has these top-level toggles (all added in **1.29.0** unless noted): `apply-member-limit-perms`, `show-limit-messages`, `stacked-plants-count-as-one`, and `log-limits-on-join`.
 
 !!! info "Per-dimension limits (1.28.2+)"
     As of **1.28.2**, block counts, entity counts, limits, and offsets are tracked **independently for the overworld, nether, and end**. A single limit defined in `blocklimits` or `entitylimits` applies separately to each dimension — e.g. `HOPPER: 10` allows 10 hoppers in the overworld, 10 in the nether, and 10 in the end (30 total across the island). Use the optional `-nether` / `-end` sections to override a single dimension.
@@ -76,6 +81,78 @@ entitygrouplimits:
       - ZOMBIE
       - CREEPER
 ```
+
+### blockgrouplimits
+
+!!! info "Since 1.29.0"
+    The block-side counterpart to `entitygrouplimits`: one shared limit across a set of block materials. The counts of every member are summed and checked against the group limit, so players can't dodge a limit by converting between related blocks (e.g. grass → dirt) or splitting across variants (piston / sticky piston). Individual `blocklimits` still apply on top if both are set.
+
+Define a named group with an `icon`, a shared `limit`, and a `materials` list:
+
+```yaml
+blockgrouplimits:
+  Pistons:
+    icon: PISTON
+    limit: 10
+    materials:
+    - PISTON
+    - STICKY_PISTON
+  Soil:
+    icon: GRASS_BLOCK
+    limit: 200
+    materials:
+    - GRASS_BLOCK
+    - DIRT
+    - DIRT_PATH
+    - FARMLAND
+```
+
+Per-environment overrides are supported via `blockgrouplimits-nether` / `blockgrouplimits-end`, which override only the numeric limit of a group already defined in `blockgrouplimits`:
+
+```yaml
+blockgrouplimits-nether:
+  Pistons: 5
+```
+
+!!! warning "Run a recount after changing groups"
+    After adding a block group (or changing `stacked-plants-count-as-one` below), run `/[player_command] limits recount` so stored counts match the new counting rules.
+
+### ItemsAdder & Oraxen custom blocks
+
+!!! info "Since 1.29.0"
+    Custom blocks from **ItemsAdder** and **Oraxen** can be limited using their ids directly in the existing `blocklimits` section (and its `-nether`/`-end` and `worlds:` overrides). Enforcement uses each plugin's own place/break events via BentoBox hooks, registered only when the plugin is installed. Quote keys containing a colon.
+
+```yaml
+blocklimits:
+  "iafestivities:christmas/christmas_tree/green_orb": 5
+  "oraxen:caveblock": 10
+```
+
+### Other toggles
+
+=== "apply-member-limit-perms"
+    !!! summary "Description"
+        (**1.29.0+**) When `true`, a team member's `<gamemode>.island.limit.*` permissions are merged into the island's limits when they log in — the highest value wins. Coop and trusted players are not team members and their permissions never apply.
+
+        Default: `false`
+
+=== "show-limit-messages"
+    !!! summary "Description"
+        (**1.29.0+**) When `false`, limits are enforced silently — placements and spawns are still blocked, but players receive no hit-limit message.
+
+        Default: `true`
+
+=== "stacked-plants-count-as-one"
+    !!! summary "Description"
+        (**1.29.0+**) When `true`, a `SUGAR_CANE` or `BAMBOO` stalk counts as a single plant no matter how tall it grows — only the base segment is counted. Run a recount after changing this option.
+
+        Default: `false`
+
+=== "log-limits-on-join"
+    !!! summary "Description"
+        Log an island's limits to the console when its owner joins. As of **1.29.0** this **defaults to `false`** (it previously defaulted to `true`) because it flooded the console on servers with many permission-based limits. Set it back to `true` if you relied on that output for debugging.
+
+        Default: `false`
 
 ## Permissions
 
@@ -139,11 +216,33 @@ Some items cannot be limited (right now). The reasons are usually because there 
 * Ender crystals
 * Ender pearls
 * Ender dragon
-* Item frames
-* Paintings
+
+!!! tip "Item frames and paintings can now be limited (1.29.0)"
+    Item frames, glow item frames, and paintings were previously on this list. Since **1.29.0** entity counting is persistent and event-driven, so all three can now be configured under `entitylimits` like any other entity.
 
 
 ## Changelog
+
+??? note "What's new in v1.29.0"
+    **Released:** 2026-07-10
+
+    Compatibility: BentoBox API 2.7.1 · Paper Minecraft 1.21.11 – 26.2 · Java 21.
+
+    - ⚙️ **Block group limits.** One shared limit across a set of block materials (e.g. pistons + sticky pistons, or grass/dirt/farmland), so players can't dodge a limit by converting between related blocks. Configured under `blockgrouplimits`, with `-nether`/`-end` overrides. See the Configuration section above.
+    - ⚙️ **ItemsAdder & Oraxen custom block limits.** Limit custom blocks straight from `blocklimits` using their namespaced ids.
+    - ⚙️ **Team member limit permissions (opt-in).** With `apply-member-limit-perms: true`, team members' `island.limit.*` permissions can contribute to the island's limits, not just the owner's.
+    - 🔡 **Reached-limits placeholders & API.** New `%Limits_<gamemode>_island_reached_limits%` placeholders (plus `_overworld`/`_nether`/`_end`) list which limits are maxed, backed by a new `Limits#getReachedLimits(...)` API. Closes the oldest open ticket in the tracker (filed in 2018).
+    - ⚙️ **Stackable plants can count as one.** Optionally count a whole sugar cane or bamboo stalk as a single plant (`stacked-plants-count-as-one`).
+    - ⚙️ **Silent enforcement option.** `show-limit-messages: false` turns off hit-limit chat messages while keeping limits enforced.
+    - 🔡 **Manual material/entity name translations.** Locale files can now translate the block/entity names shown in the GUI and hit-limit messages.
+    - **Item frames, glow item frames, and paintings can now be limited** under `entitylimits`.
+    - 🐛 **Fix: phantom entity counts from portaled mobs** (e.g. `Chicken 10/10` with no chickens on the island) and a copper golem build bypassing the `COPPER_CHEST` limit.
+    - ⚙️ **`log-limits-on-join` now defaults to `false`** — set it back to `true` if you relied on that console output.
+
+    !!! warning "New config options are not added automatically"
+        New keys do **not** appear in an existing `config.yml` — add the ones you want from the list above, or delete the config to regenerate it. After adding a block group or changing `stacked-plants-count-as-one`, run a recount so stored counts match the new counting rules.
+
+    [Release v1.29.0](https://github.com/BentoBoxWorld/Limits/releases/tag/1.29.0)
 
 ??? note "What's new in v1.28.4"
     **Released:** 2026-07-06

--- a/docs/gamemodes/CaveBlock/index.md
+++ b/docs/gamemodes/CaveBlock/index.md
@@ -162,6 +162,16 @@ Addon introduces 1 BentoBox Settings flag:
 
 ## Changelog
 
+??? note "What's new in v1.23.1"
+    **Released:** 2026-07-09
+
+    A bugfix release that closes the structure-suppression hole introduced in 1.23.0. Recommended for all servers running 1.23.0 that disable vanilla structures.
+
+    - 🔺 **Disabled structures no longer freeze the server.** Disabling a structure only cancelled its *placement*, not its placement *rules*, so structure searches (`/locate`, Eyes of Ender, explorer/treasure maps, dolphins, villager map trades) kept scanning out to the radius cap and freezing the main thread. A new `StructuresLocateEvent` handler now removes disabled structures from the search up front, returning "not found" instantly. Fixes [#116](https://github.com/BentoBoxWorld/CaveBlock/issues/116).
+    - 🔺 **Structures no longer slip through in the spawn area.** The suppression listener is now registered early in `createWorlds()`, before the first spawn chunks generate, so a disabled structure can no longer appear near spawn.
+
+    [Release v1.23.1](https://github.com/BentoBoxWorld/CaveBlock/releases/tag/1.23.1)
+
 ??? note "What's new in v1.23.0"
     **Released:** 2026-07-07
 


### PR DESCRIPTION
## Summary

Originally this PR re-documented the same releases as #72 (which merged to `master` first). It has been rebased onto `master` and reduced to **only the releases published after #72's run** — everything already covered by #72 (BentoBox 3.19.0, CaveBlock 1.22.0/1.23.0, Limits 1.28.4, MagicCobblestoneGenerator 2.9.0) has been dropped to avoid duplication.

Remaining, genuinely-new content:

| Repo | Previous (on master) | New |
|---|---|---|
| Limits | 1.28.4 | 1.29.0 |
| CaveBlock | 1.23.0 | 1.23.1 |

## Changes

### Limits (1.28.4 → 1.29.0)
- Documented `blockgrouplimits` (+ `-nether`/`-end`), ItemsAdder/Oraxen custom-block ids, and the `apply-member-limit-perms` / `show-limit-messages` / `stacked-plants-count-as-one` / `log-limits-on-join` toggles
- Added `%Limits_<gamemode>_island_reached_limits%` placeholders (+ `_overworld`/`_nether`/`_end`) to `data/placeholders.csv`
- Noted item frames / glow item frames / paintings are now limitable (removed from the "cannot be limited" list)
- Added a v1.29.0 changelog entry

### CaveBlock (1.23.0 → 1.23.1)
- Added a v1.23.1 changelog entry (structure-suppression freeze / spawn-area bugfix). The `structures` / `overworld-cave-fill` / `overworld-carvers` config and the 1.22.0/1.23.0 changelogs were already added by #72.

### Tracker
- `data/release-tracker.json`: CaveBlock 1.23.0 → 1.23.1, Limits 1.28.4 → 1.29.0

## Verification

- [x] `mkdocs build --strict` passes with zero warnings (with `GITHUB_TOKEN` set so the `translations()` macro isn't rate-limited)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RqnfBgPmGhM8BxCVv5kHip