### PR TITLE
docs: document BentoBox 3.20.0 and MagicCobblestoneGenerator 2.10.0

### DIFF
--- a/data/release-tracker.json
+++ b/data/release-tracker.json
@@ -1,9 +1,9 @@
 {
-  "last_run": "2026-07-11T00:00:00Z",
+  "last_run": "2026-07-11T23:36:19Z",
   "repos": {
     "BentoBox": {
-      "last_checked": "2026-07-08T02:07:59Z",
-      "last_release": "3.19.0",
+      "last_checked": "2026-07-11T23:36:19Z",
+      "last_release": "3.20.0",
       "doc_path": "BentoBox/",
       "category": "core"
     },
@@ -158,8 +158,8 @@
       "category": "addon"
     },
     "MagicCobblestoneGenerator": {
-      "last_checked": "2026-07-08T02:07:59Z",
-      "last_release": "2.9.0",
+      "last_checked": "2026-07-11T23:36:19Z",
+      "last_release": "2.10.0",
       "doc_path": "addons/MagicCobblestoneGenerator/index.md",
       "category": "addon"
     },

--- a/docs/BentoBox/About/AdminTools.md
+++ b/docs/BentoBox/About/AdminTools.md
@@ -105,7 +105,20 @@ This reloads BentoBox and all addons, including locales. Note that some changes 
 
 ## Changelog
 
-!!! warning "What's new in v3.19.0 — bed/anchor respawns now honored"
+!!! note "What's new in v3.20.0 — command suggestions & core structure suppression"
+    **Released:** 2026-07-11
+
+    A quality-of-life release. Compatibility: Paper Minecraft 1.21.5 – 26.2, Java 25+. Nothing changes on upgrade unless you opt in.
+
+    - 🔡 ⚙️ **Did-you-mean command suggestions.** A mistyped command like `/teams` or `/island invit Floris` now offers the closest matching BentoBox command — clickable, or accept by typing `yes`/`y` within 30 seconds — instead of dumping the help text. Suggestions match labels and aliases across every command tree, are permission-filtered, and use the game-mode world the player is standing in to disambiguate. Two new toggles under `general.did-you-mean` in `config.yml` — `unknown-commands` and `subcommands` — both default **on**; set either to `false` and `/bbox reload` to disable.
+    - ⚙️ 🔺 **Core vanilla-structure suppression for every game mode.** Disabling a vanilla structure is now a single core setting instead of a per-addon job. A new `world.disabled-structures` list in `config.yml` (applied to every BentoBox overworld/nether/end) stops the listed structures generating **and** skips them in structure searches — `/locate`, Eyes of Ender, explorer/treasure maps, dolphins and villager cartographer trades — fixing the long-standing `/locate` main-thread freeze and near-spawn structure leaks. Keys are case- and separator-insensitive (`trial_chambers`, `ancient-city`). A game mode can override the list per-structure. **The list is empty by default, so behaviour is unchanged until you opt in.**
+    - 🔌 **Nexo hook.** BentoBox can now place and detect [Nexo](https://nexomc.com/) custom blocks and items, alongside the other custom-item integrations.
+    - 🔌 **Oraxen block placement.** `OraxenHook.placeBlock` exposes Oraxen custom-block placement to addons, matching the other custom-block hooks.
+    - 🔡 **Locale note:** three new `general.did-you-mean` keys were added to all 22 bundled locales, and the pre-existing missing key `commands.admin.team.setowner.specify-island` was filled in every non-English file. Regenerate or update any custom locale files.
+
+    [Release v3.20.0](https://github.com/BentoBoxWorld/BentoBox/releases/tag/3.20.0)
+
+??? warning "What's new in v3.19.0 — bed/anchor respawns now honored"
     **Released:** 2026-07-08
 
     Compatibility: Paper Minecraft 1.21.5 – 26.2, Java 25+.

--- a/docs/addons/MagicCobblestoneGenerator/index.md
+++ b/docs/addons/MagicCobblestoneGenerator/index.md
@@ -168,6 +168,20 @@ Since **2.9.0** generators can be gated behind richer requirements so you can de
 !!! warning "Permission-gated generators are now revoked"
     Since **2.9.0**, a generator unlocked via permission is re-checked and **revoked** from an island's unlocked and active lists when the current (online) owner no longer holds the required permission — for example after an ownership transfer. Purchased tiers are preserved, so access returns if the permission is regained; offline owners are left untouched. Previously such a grant was permanent.
 
+### Custom block outputs (ItemsAdder, CraftEngine, Oraxen, Nexo)
+
+Since **2.10.0** a generator tier can produce **custom blocks** from ItemsAdder, CraftEngine, Oraxen and Nexo, not just vanilla materials — for example a diamond-encrusted ItemsAdder ore rolls into the weighted-random mix alongside everything else. All access to those plugins is routed through BentoBox core hooks, so the addon never depends on them directly.
+
+- Blocks are stored as string IDs: vanilla names such as `COBBLESTONE`, or provider-prefixed IDs `itemsadder:namespace:id`, `craftengine:namespace:id`, `oraxen:id`, `nexo:id`. **Existing databases and templates load unchanged.**
+- The admin edit panel gains an **Add Custom Block** button — enter the ID in chat and it is validated against the hook registry. Panels render custom blocks with the provider's own texture and display name.
+- If a picked custom block is unavailable at generation time (the provider or block is missing), the generator falls back to the vanilla block and reports why via `/[admin_command] generator why`, rather than failing silently. Unregistered custom blocks in a template import with a warning so templates stay portable across servers.
+
+!!! note "Provider availability"
+    ItemsAdder and CraftEngine generate blocks today. Oraxen and Nexo are wired up and will generate once the matching BentoBox core hooks ship (BentoBox 3.20.0 adds the Nexo hook and `OraxenHook.placeBlock`).
+
+!!! warning "Requires BentoBox 3.19.1 or newer"
+    2.10.0 depends on the custom-block hook API added in BentoBox 3.19.1 and **will not load on an older core**. Update BentoBox before dropping in this jar.
+
 ## Commands
 
 !!! tip
@@ -318,6 +332,20 @@ Since **2.9.0** generators can be gated behind richer requirements so you can de
     ```
 
 ## Changelog
+
+??? warning "What's new in v2.10.0 — custom blocks, requires BentoBox 3.19.1"
+    **Released:** 2026-07-11
+
+    Generators can now drop custom blocks from other plugins, routed through BentoBox core hooks.
+
+    - 🔺 **Custom block support.** Generator tiers can produce blocks from **ItemsAdder, CraftEngine, Oraxen and Nexo** as well as vanilla materials. Blocks are stored as string IDs (`COBBLESTONE`, or `itemsadder:namespace:id`, `craftengine:namespace:id`, `oraxen:id`, `nexo:id`); existing databases load unchanged. Fixes [#103](https://github.com/BentoBoxWorld/MagicCobblestoneGenerator/issues/103). See the Configuration section above.
+    - ✨ **Add Custom Block panel button** with chat-input validation against the hook registry; panels render custom blocks with the provider's own texture and name. Unavailable custom blocks fall back to the vanilla block with a `/why` report instead of failing silently. ItemsAdder and CraftEngine generate today; Oraxen and Nexo generate once BentoBox 3.20.0's hooks are present.
+    - 🐛 **Treasure chance edits now save.** Editing a treasure's chance in the admin panel wrote to the deprecated `treasureChanceMap` instead of `treasureItemChanceMap`, so edits were lost — fixed.
+    - ⚙️ **Templates accept custom blocks.** `generatorTemplate.yml` now accepts quoted, provider-prefixed block keys. No config action is required for existing setups; unregistered custom blocks import with a warning.
+    - 🔡 **Locale note:** new `en-US.yml` keys were added for the custom block UI. Regenerate or update your locale files to pick up the new strings.
+    - 🔺 **Requires BentoBox 3.19.1 or newer.** The custom-block hook API this release calls is only available from 3.19.1; the addon will not load on an older core. Update BentoBox first.
+
+    [Release v2.10.0](https://github.com/BentoBoxWorld/MagicCobblestoneGenerator/releases/tag/2.10.0)
 
 ??? warning "What's new in v2.9.0 — permission-gated generators now revoked"
     **Released:** 2026-07-08


### PR DESCRIPTION
## Summary

Documentation updates triggered by new releases detected since the last run (2026-07-11):

| Repo | Previous | New |
|---|---|---|
| BentoBox | 3.19.0 | 3.20.0 |
| MagicCobblestoneGenerator | 2.9.0 | 2.10.0 |

## Changes per repo

### BentoBox (3.19.0 → 3.20.0)
- Added a **What's new in v3.20.0** changelog entry to `docs/BentoBox/About/AdminTools.md` (and collapsed the previous 3.19.0 entry), covering:
  - 🔡 ⚙️ Did-you-mean command suggestions — new `general.did-you-mean` config toggles (`unknown-commands`, `subcommands`), both default on.
  - ⚙️ 🔺 Core vanilla-structure suppression via `world.disabled-structures` (empty by default), fixing the `/locate` main-thread freeze and near-spawn structure leaks.
  - 🔌 Nexo hook and `OraxenHook.placeBlock` custom-block placement.
  - 🔡 Three new `general.did-you-mean` locale keys across all bundled locales.

### MagicCobblestoneGenerator (2.9.0 → 2.10.0)
- Added a **Custom block outputs** subsection to the Configuration section documenting ItemsAdder / CraftEngine / Oraxen / Nexo custom-block generation, the Add Custom Block panel button, string-ID storage, graceful vanilla fallback, provider availability, and the BentoBox 3.19.1+ requirement.
- Added a **What's new in v2.10.0** changelog entry (custom blocks, treasure-chance fix, template support, locale note, core-version requirement).

No new flags or placeholders were introduced by either release, so `data/flags.csv` and `data/placeholders.csv` are unchanged. `data/release-tracker.json` updated to the new release tags.

## Verification

- [x] `mkdocs build --strict` passes with zero warnings

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01C4jhaZu8ScTHmYNeRBsv9z