### PR TITLE
docs: update documentation for releases 2026-07-25

### DIFF
--- a/data/release-tracker.json
+++ b/data/release-tracker.json
@@ -1,21 +1,21 @@
 {
-  "last_run": "2026-07-11T23:36:19Z",
+  "last_run": "2026-07-26T04:16:18Z",
   "repos": {
     "BentoBox": {
-      "last_checked": "2026-07-11T23:36:19Z",
-      "last_release": "3.20.0",
+      "last_checked": "2026-07-26T04:16:18Z",
+      "last_release": "3.21.0",
       "doc_path": "BentoBox/",
       "category": "core"
     },
     "AcidIsland": {
-      "last_checked": "2026-05-23T00:37:17Z",
-      "last_release": "1.22.0",
+      "last_checked": "2026-07-26T04:16:18Z",
+      "last_release": "2.0.0",
       "doc_path": "gamemodes/AcidIsland/index.md",
       "category": "gamemode"
     },
     "AOneBlock": {
-      "last_checked": "2026-07-08T02:07:59Z",
-      "last_release": "1.25.1",
+      "last_checked": "2026-07-26T04:16:18Z",
+      "last_release": "1.26.2",
       "doc_path": "gamemodes/AOneBlock/index.md",
       "category": "gamemode"
     },
@@ -110,8 +110,8 @@
       "category": "addon"
     },
     "ExtraMobs": {
-      "last_checked": "2026-05-23T00:37:17Z",
-      "last_release": "",
+      "last_checked": "2026-07-26T04:16:18Z",
+      "last_release": "1.15.0",
       "doc_path": "addons/ExtraMobs/index.md",
       "category": "addon"
     },
@@ -122,8 +122,8 @@
       "category": "addon"
     },
     "Greenhouses": {
-      "last_checked": "2026-06-04T14:25:55Z",
-      "last_release": "1.9.5",
+      "last_checked": "2026-07-26T04:16:18Z",
+      "last_release": "1.10.0",
       "doc_path": "addons/Greenhouses/index.md",
       "category": "addon"
     },
@@ -152,8 +152,8 @@
       "category": "addon"
     },
     "Limits": {
-      "last_checked": "2026-07-11T00:00:00Z",
-      "last_release": "1.29.0",
+      "last_checked": "2026-07-26T04:16:18Z",
+      "last_release": "1.29.1",
       "doc_path": "addons/Limits/index.md",
       "category": "addon"
     },

--- a/docs/BentoBox/About/AdminTools.md
+++ b/docs/BentoBox/About/AdminTools.md
@@ -105,7 +105,19 @@ This reloads BentoBox and all addons, including locales. Note that some changes 
 
 ## Changelog
 
-!!! note "What's new in v3.20.0 — command suggestions & core structure suppression"
+!!! note "What's new in v3.21.0 — modal dialogs"
+    **Released:** 2026-07-22
+
+    A player-experience release. Compatibility: Paper Minecraft 1.21.5 – 26.2, Java 25+.
+
+    - ⚙️ 🔡 **Modal dialogs for high-friction flows.** Sensitive-command confirmations, the `/island go` destination picker, team invites, and a first-join game-mode chooser can now appear as real modal dialogs the player cannot misread or scroll past. A new `island.dialogs` section in `config.yml` holds one toggle per flow — `confirmations`, `go-picker` and `team-invites` default **on**, `game-mode-selection` defaults **off** because it is intrusive by design. Dialogs need a Minecraft 26+ server; on anything older every toggle is ignored and the classic chat/command behaviour is used, so no action is needed there.
+    - **Forgiving `/island go` matching.** `/island go myisland`, `hom`, or a name typed with the wrong case or a stray double space now teleports the player where they meant instead of failing an exact match and dumping the full list. See [Home Locations](IslandManagement.md#home-locations).
+    - 🔡 **Locale note:** new dialog keys (`general.dialogs.*`, plus dialog and picker keys under the confirmation, `island go` and team-invite commands) were added to all 22 bundled locales. Regenerate or update any custom locale files.
+    - 🔧 **Addon developers** get the same `world.bentobox.bentobox.api.dialogs` API used by core — see [Modal dialogs](../Developer-Documentation.md#modal-dialogs).
+
+    [Release v3.21.0](https://github.com/BentoBoxWorld/BentoBox/releases/tag/3.21.0)
+
+??? note "What's new in v3.20.0 — command suggestions & core structure suppression"
     **Released:** 2026-07-11
 
     A quality-of-life release. Compatibility: Paper Minecraft 1.21.5 – 26.2, Java 25+. Nothing changes on upgrade unless you opt in.

--- a/docs/BentoBox/About/IslandManagement.md
+++ b/docs/BentoBox/About/IslandManagement.md
@@ -25,6 +25,18 @@ Players can set multiple home locations on their island with `/island sethome`. 
 [gamemode].island.home.maxhomes.<number>
 ```
 
+### Finding the right home
+
+Since BentoBox 3.21.0, `/island go <name>` no longer needs an exact, case-sensitive match. The typed name is resolved in decreasing order of confidence:
+
+1. An exact match on an island or home name.
+2. A match ignoring case, colour codes and extra whitespace — so `myisland` finds `MyIsland` and a stray double space is forgiven.
+3. A unique case-insensitive prefix — `hom` finds `Home`.
+
+Anything still ambiguous falls through to the usual list of destinations rather than guessing, and the resolved canonical name is used for the teleport so named homes stay accurate.
+
+If the player runs `/island go` with no name at all and has more than one island or home to pick from, BentoBox can show a **destination picker** — a modal dialog with one button per destination. This needs a Minecraft 26+ server and is controlled by `island.dialogs.go-picker` in BentoBox's `config.yml` (default `true`). On older servers, or with the toggle off, the classic clickable chat list is shown instead.
+
 ## Resetting an Island
 
 Players can start fresh by resetting their island with `/island reset`. This **deletes the current island** and creates a brand new one. Admins can:

--- a/docs/BentoBox/About/Teams.md
+++ b/docs/BentoBox/About/Teams.md
@@ -140,6 +140,12 @@ There is a small chance that the inviter loses the rank required to invite playe
 !!! tip "Confirmation time"
     The default time players have to confirm a command is 10 seconds. If your players need more time, increase this value in BentoBox's `config.yml`. Players can also press the up arrow to recall the previous command rather than retyping it.
 
+#### Invite dialogs
+
+Since BentoBox 3.21.0, receiving a team invite can automatically open a modal **[Accept] / [Decline]** dialog, so the player does not have to notice the chat message and type the accept or reject command. This needs a Minecraft 26+ server and is controlled by `island.dialogs.team-invites` in BentoBox's `config.yml` (default `true`). On older servers, or with the toggle off, the invite arrives as the usual chat message.
+
+Sensitive-command confirmations — such as `team kick` and `team leave` — can likewise be shown as a **[Confirm] / [Cancel]** dialog instead of asking the player to type the command a second time. That is `island.dialogs.confirmations` (default `true`), and it falls back to the type-it-again behaviour whenever dialogs are unavailable.
+
 #### What happens when a player accepts
 
 When a player accepts a team invite, BentoBox automatically:

--- a/docs/BentoBox/Developer-Documentation.md
+++ b/docs/BentoBox/Developer-Documentation.md
@@ -61,3 +61,39 @@ PlayerEvent.builder()
 ```
 
 This is purely additive — all classes are new and no existing API changed, so 3.17.0 is binary-compatible with existing addons. The [Inventory Switcher addon](../addons/InvSwitcher/index.md) uses these events to protect per-world inventories and balances during resets. See [Release 3.17.0](https://github.com/BentoBoxWorld/BentoBox/releases/tag/3.17.0).
+
+# Modal dialogs
+
+*Added in BentoBox 3.21.0.*
+
+`world.bentobox.bentobox.api.dialogs` wraps Paper's modal dialog system, which requires **Minecraft 26 or later**. Dialogs sit alongside the Panels API: a panel is an inventory the player can click away, a dialog is a modal the player has to answer. Core uses them for command confirmations, the `/island go` destination picker, team invites, and the first-join game-mode chooser.
+
+| Class | Purpose |
+| --- | --- |
+| `Dialogs` | `Dialogs.isSupported()` — whether this server can show dialogs |
+| `DialogBuilder` | Fluent builder: `title`, `body`, `escapable`, `pause`, `confirmation`, `button`, `build` |
+| `DialogButton` | A label, an optional tooltip, and a `Consumer<User>` click handler |
+| `BBDialog` | The built dialog — `show(User)` to display it |
+
+`title(...)`, `body(...)` and `DialogButton.of(...)` each take either an Adventure `Component` or a `User` plus a locale reference (with optional variables), so dialog text is translated the same way as the rest of your addon. Everything is `Component`-based end to end, so click actions survive.
+
+```java
+if (!Dialogs.isSupported()) {
+    // Pre-26 server: fall back to your chat or panel flow
+    askInChat(user);
+    return;
+}
+new DialogBuilder()
+    .title(user, "myaddon.confirm.title")
+    .body(user, "myaddon.confirm.body", "[name]", island.getName())
+    .confirmation(
+        DialogButton.of(user, "myaddon.confirm.yes", u -> doTheThing(u)),
+        DialogButton.of(user, "myaddon.confirm.no", u -> u.sendMessage("myaddon.confirm.cancelled")))
+    .build()
+    .show(user);
+```
+
+!!! warning "Always provide a fallback"
+    Check `Dialogs.isSupported()` and keep your previous chat or panel behaviour for older servers, exactly as core does. Button click handlers run on the main thread, so they can touch the Bukkit API directly.
+
+See [Release 3.21.0](https://github.com/BentoBoxWorld/BentoBox/releases/tag/3.21.0).

--- a/docs/addons/ExtraMobs/index.md
+++ b/docs/addons/ExtraMobs/index.md
@@ -38,14 +38,86 @@ Addon will replace Cod, Salmon or Tropical fish with Guardian by chance from con
  - biome in given location is deep ocean or any its variants
  - first block above water where fish is spawned is prismarine, prismarine brick or dark prismarine (blocks, slabs and stairs).     
 
+## Configuration
+
+The latest `config.yml` can be found [here](https://github.com/BentoBoxWorld/ExtraMobs/blob/develop/src/main/resources/config.yml).
+
+??? note "disabled-gamemodes"
+    A list of GameModes in which the addon should not work. Each entry goes on its own line starting with `-`.
+
+    Default: `[]` (empty — the addon runs in every GameMode)
+
+??? note "nether-chances"
+    Chances of replacing a Zombified Piglin in the Nether. `wither-skeleton` and `blaze` are each a probability in the range 0.0–1.0.
+
+    Defaults: `wither-skeleton: 0.01`, `blaze: 0.1`
+
+??? note "end-chances"
+    `shulker` — chance of replacing an Enderman in the End with a Shulker.
+
+    Default: `0.1`
+
+??? note "overworld-chance"
+    `guardian` — chance of replacing a Cod, Salmon or Tropical Fish in the Overworld with a Guardian.
+
+    Default: `0.1`
+
+??? note "gamemode-settings"
+    Per-GameMode replacement rules that override the global chances above. Added in 1.15.0.
+
+    Each key is the exact GameMode addon name (case-sensitive), and each GameMode may define up to three environment sections — `world:` for the overworld, `nether:`, and `end:`. Each section is a list of rules with `old` (the `EntityType` to replace), `new` (the replacement `EntityType`), and `chance` (0.0–1.0).
+
+    Per-GameMode rules are tried in order before the global defaults for that environment. If a rule matches the spawning entity **and** its chance roll succeeds, the replacement is applied and processing stops for that event. If no rule matches, or every matching rule's roll fails, the global `nether-chances` / `end-chances` / `overworld-chance` values are used as a fallback.
+
+    Default: `{}` — opt-in, so the global chances continue to apply to any GameMode not listed here.
+
+    ```yaml
+    gamemode-settings:
+      BSkyBlock:
+        nether:
+          - old: ZOMBIFIED_PIGLIN
+            new: WITHER_SKELETON
+            chance: 0.05
+          - old: ZOMBIFIED_PIGLIN
+            new: BLAZE
+            chance: 0.1
+        end:
+          - old: ENDERMAN
+            new: SHULKER
+            chance: 0.3
+        world:
+          - old: COD
+            new: GUARDIAN
+            chance: 0.15
+      AcidIsland:
+        end:
+          - old: ENDERMAN
+            new: SHULKER
+            chance: 0.5
+    ```
+
 ## Compatibility
 
-- [x] BentoBox - 1.11.0 version
+- [x] BentoBox 3.14.0 or later
+- [x] Paper Minecraft 1.21.x
+- [x] Java 21 or later
 
-Addon is build on Minecraft 1.15.2 and BentoBox 1.11.0 version, however, it should even work on Minecraft 1.13.2 and BentoBox 1.0 Release.
-
-Addon supports all Game mode addons.
+The addon supports all game mode addons.
 
 ## Translations
 
 {{ translations("ExtraMobs") }}
+
+## Changelog
+
+!!! note "What's new in v1.15.0 — Java 21 and BentoBox 3.14.0 required"
+    **Released:** 2026-05-31
+
+    Compatibility: BentoBox API 3.14.0+ · Paper Minecraft 1.21.x · Java 21+.
+
+    - ⚙️ **Per-GameMode spawn replacement rules.** A new `gamemode-settings` config block defines replacement rules for each BentoBox GameMode separately, rather than sharing one global setting across the whole server. It defaults to `{}` and is opt-in, so the existing global chance values continue to work for any GameMode that is not listed. See the Configuration section above.
+    - 🔺 **Java 21 and BentoBox 3.14.0 are now required.** Make sure your server meets both before upgrading.
+    - **Pladdon entry point and `plugin.yml` added,** so the addon loads as a modern BentoBox addon.
+    - Test suite rebuilt on JUnit 5 and MockBukkit, GitHub Actions build with SonarCloud analysis added, and various maintainability issues resolved.
+
+    [Release v1.15.0](https://github.com/BentoBoxWorld/ExtraMobs/releases/tag/1.15.0)

--- a/docs/addons/Greenhouses/Permissions.md
+++ b/docs/addons/Greenhouses/Permissions.md
@@ -4,3 +4,10 @@
 |-------------------------------------|-----------------------------------------------------------------------------------------------------------------------------------------------------|-------------|
 | [gamemode].greenhouses.player       | Gives access to player commands - change [gamemode] to your gamemode, e.g., bskyblock, acidisaland, aoneblock, etc.                                  | true        |
 | [gamemode].greenhouses.admin        | Gives access to admin commands                                                                                                                      | op          |
+| [gamemode].greenhouses.admin.list   | Allows listing greenhouses (since 1.10.0)                                                                                                           | op          |
+| [gamemode].greenhouses.admin.info   | Allows viewing the detail of a greenhouse (since 1.10.0)                                                                                            | op          |
+| [gamemode].greenhouses.admin.delete | Allows deleting a greenhouse record (since 1.10.0)                                                                                                  | op          |
+| [gamemode].greenhouses.admin.tp     | Allows teleporting to a greenhouse (since 1.10.0)                                                                                                   | op          |
+| [gamemode].greenhouses.admin.verify | Allows re-checking greenhouses against their recipe (since 1.10.0)                                                                                  | op          |
+| [gamemode].greenhouses.admin.reload | Allows reloading biomes.yml and the greenhouse database (since 1.10.0)                                                                              | op          |
+| greenhouses.biome.nether            | Gives access to nether biomes. Per-biome permissions are set in `biomes.yml` - see the [Greenhouses page](index.md#permissions).                     | true        |

--- a/docs/addons/Greenhouses/index.md
+++ b/docs/addons/Greenhouses/index.md
@@ -79,21 +79,39 @@ Read the file release notes for changes and instructions on how to upgrade.
 
 ## Player Commands
 
-Add these commands to /island, /ai:
+Add these commands to /island, /ai. The command label is `greenhouse`, with the aliases `gh` and `greenhouses`.
 
+* **greenhouses** - opens the recipe GUI; clicking on a recipe tries to make that greenhouse
 * **greenhouses help** - lists these commands
-* **greenhouses make**: Tries to make a greenhouse by finding the first valid recipe
+* **greenhouses make [recipe]**: Tries to make a greenhouse, by finding the first valid recipe or by using the named one
 * **greenhouses remove**: Removes a greenhouse that you are standing in if you are the owner
-* **greenhouses list**: Lists all the recipes available
-* **greenhouses recipe**: Display the recipe GUI - clicking on a recipe will try to make a greenhouse
+
+!!! warning "`list` and `recipe` were removed in 1.10.0"
+    These two player commands were documented but never actually registered — they were unreachable stubs, and calling them only ever produced an unknown-command error. They were deleted in 1.10.0. `/is greenhouses` with no arguments opens the recipe GUI, which is what they were supposed to do.
 
 ## Admin Commands
 
-Use after the game mode admin command, e.g. /bsb or /acid
+!!! new "Added in Greenhouses 1.10.0"
+    Before 1.10.0 the addon had no admin command tree at all. If a greenhouse record went bad, the only option was to stop the server and edit the database by hand.
 
-* **greenhouses reload** : Reloads config files
-* **greenhouses info <player>**: provides info on the player's island greenhouses
-* **greenhouses info**: provides info on the greenhouse you are in
+Registered under your game mode's admin command, e.g. `/bsbadmin greenhouses` or `/acid greenhouses`. The label is `greenhouses`, with the aliases `greenhouse` and `gh`.
+
+| Command | What it does |
+|---|---|
+| `list [player] [page]` | Paginated list of greenhouses, optionally just one player's. Records that failed to load are **always** listed too, with the reason. |
+| `info [id]` | Recipe, owner, world, location, bounding box, area, original biome, hopper, broken status and missing blocks. With no ID, uses the greenhouse you are standing in. |
+| `delete <id>` | Deletes a record — loaded or not — after asking you to confirm. |
+| `tp <id>` | Teleports you to the middle of the greenhouse floor. Alias: `teleport`. |
+| `verify [id]` | Re-checks one or all greenhouses against their recipe and reports what is missing. Alias: `check`. |
+| `reload` | Re-reads `biomes.yml`, then re-loads the greenhouses from the database. |
+
+- IDs come from `list` and can be shortened to any prefix that matches **only one** greenhouse. An ambiguous prefix is treated as no match rather than a guess, because deleting the wrong greenhouse cannot be undone.
+- Everything except `tp` works from the server console.
+- Greenhouse records that cannot be loaded — overlapping, unknown recipe, missing world, no location — are kept in memory with the reason instead of being silently dropped. That is what makes them listable and deletable.
+- Records are never deleted automatically. Removing a player's greenhouse without being asked would be worse than a recurring warning.
+
+!!! tip "Overlapping greenhouses"
+    If two persisted greenhouses overlap, one is skipped at startup and named in the log along with the record it overlaps. Use `/bsbadmin greenhouses list` to see the skipped records and why, then `/bsbadmin greenhouses delete <id>` to remove the one you do not want. No database editing and no restart needed.
 
 ## Permissions
 
@@ -121,9 +139,42 @@ The permission can be anything you like, e.g., a rank permission, **myserver.VIP
      description: Gives access to admin commands
      default: op
 
+Since 1.10.0 each admin sub-command also has its own node — `greenhouses.admin.list`, `.info`, `.delete`, `.tp`, `.verify` and `.reload` — all defaulting to `op`. Operators need no action, but if you grant admin access through a permissions plugin you will want to add them. They were missing from `addon.yml` entirely before that release, which is why nothing but op access worked.
+
 ## Translations
 
 {{ translations("Greenhouses") }}
+
+!!! note "What's new in v1.10.0 — admin commands"
+    **Released:** 2026-07-26
+
+    Greenhouses finally has an admin command tree. Compatibility: BentoBox API 2.7.1 · Minecraft 1.21.5+ · Java 21.
+
+    - 🛠️ **Admin commands.** `list`, `info`, `delete`, `tp`, `verify` and `reload`, registered under your game mode's admin command (e.g. `/bsbadmin greenhouses`). See the Admin Commands section above. Greenhouse records that cannot be loaded — overlapping, unknown recipe, missing world, no location — are now kept in memory with the reason instead of being silently dropped, which is what makes them showable and deletable. Records are still never deleted automatically.
+    - ⚙️ **New permissions.** The six sub-commands each have their own node under `greenhouses.admin.*`, all defaulting to `op`. They were missing from `addon.yml` entirely before this release, which is why nothing but op access worked.
+    - 🐛 **Checking a greenhouse whose recipe no longer exists no longer throws an NPE.** When a database record names a recipe that is not in `biomes.yml`, the check now reports `FAIL_UNKNOWN_RECIPE`.
+    - 🐛 **`getFloorHeight` no longer throws on a record with no location** — the very records most likely to be broken. It falls back to the bounding box.
+    - 🔺 **Snow now reports success from every column it scanned,** not just the last one. `SnowTracker` was overwriting its result on each column, so a greenhouse that made snow in ninety columns and missed the last reported failure — and that value decides whether water is consumed from the hopper.
+    - 🧹 All 68 open SonarCloud issues resolved, five methods refactored below the cognitive-complexity threshold, dead code removed, and the test suite grown from 177 to 224 tests.
+
+    🔡 **Translators wanted.** The admin commands add messages under `greenhouses.commands.admin.*`, currently English only. The other 24 locale files fall back to the key names until they are translated.
+
+    🔺 **Three player commands were deleted — but none of them worked.** `InfoCommand`, `ListCommand` and `RecipeCommand` were unregistered stubs with placeholder bodies. `InfoCommand` even declared itself under the label `make`, which would have collided with the real make command had anyone ever enabled it. This page previously listed `greenhouses list` and `greenhouses recipe` as working player commands; they were not, and that has been corrected. `/is greenhouses` with no arguments still opens the recipe GUI.
+
+    [Release v1.10.0](https://github.com/BentoBoxWorld/Greenhouses/releases/tag/1.10.0)
+
+??? warning "What's new in v1.9.6 — overlapping greenhouses are now diagnosable"
+    **Released:** 2026-07-25
+
+    - 🐛 **Overlapping greenhouses are now diagnosable.** If two persisted greenhouses overlap, one is skipped at startup — but the log line used to say only `Greenhouse overlaps with another greenhouse. Skipping...`, which gave you nothing to act on and repeated on every restart. The warning now names **both** records with their `uniqueId`, recipe, owner, world, location and bounding box, and tells you how to fix it. The summary line reads `Loaded 63 greenhouses out of 65 in the database.` and closes with a tally of how many were skipped.
+    - 🔺 **Greenhouse load order is now deterministic.** Greenhouses were loaded in whatever order the database returned, so with two overlapping records either could win, and it could flip between restarts. They are now sorted by `uniqueId` before loading, so the outcome is stable until you remove one of the records.
+    - ⚙️ **Duplicate `SQUID` entry removed from the `OCEAN` recipe** in `biomes.yml`. It was listed twice, which triggers a duplicate-key warning from SnakeYAML on newer server versions. YAML keeps the last occurrence, so the effective value (`20:WATER`) is preserved and mob spawning is unchanged.
+
+    ⚙️ **The `biomes.yml` fix does not apply itself.** Your server already has its own `biomes.yml` on disk and the addon will not overwrite it. If you see a SnakeYAML duplicate-key warning for `SQUID`, open `plugins/BentoBox/addons/Greenhouses/biomes.yml`, find the `OCEAN` section, and delete the first of the two `SQUID:` lines. First-time installs get the corrected file automatically.
+
+    🔺 **This release reports overlapping greenhouses but does not remove them.** Skipped records are left in the database on purpose — silently deleting a player's greenhouse would be worse than a recurring warning. In 1.9.6 you had to remove the stale record yourself using the `uniqueId`s now printed in the log; 1.10.0 adds admin commands that do it in-game.
+
+    [Release v1.9.6](https://github.com/BentoBoxWorld/Greenhouses/releases/tag/1.9.6)
 
 ??? note "What's new in v1.9.5"
     **Released:** 2026-06-03

--- a/docs/addons/Limits/index.md
+++ b/docs/addons/Limits/index.md
@@ -223,6 +223,20 @@ Some items cannot be limited (right now). The reasons are usually because there 
 
 ## Changelog
 
+??? note "What's new in v1.29.1"
+    **Released:** 2026-07-23
+
+    Compatibility: BentoBox API 2.7.1 · Paper Minecraft 1.21.11 – 26.2 · Java 21. No config or locale changes — this is a drop-in replacement.
+
+    - 🐛 **Natural breeding now respects entity limits.** Breeding that happens without a player involved (bees, foxes, villager-run breeders, and similar) bypassed the limit check entirely, so counts could grow past the configured limit. All breeding is now checked. Players with op or the bypass permission are still exempt.
+    - 🐛 **Auto-breeders no longer retry every tick.** When a breed attempt is refused at the limit, both parents are put on a breeding cooldown, and no hit-limit message is sent to nearby players unless a player actually fed the animals.
+    - 🐛 **Player entries no longer leak into the entity tracking map.** Players were being added to the entity-island tracking map and never removed.
+    - 🐛 **Boats are now included in `recount`.** The admin recount counted minecarts but skipped boats, which zeroed boat counts that the live tracker could not then recover.
+
+    Thanks to [@daniel-skopek](https://github.com/daniel-skopek) for the fixes.
+
+    [Release v1.29.1](https://github.com/BentoBoxWorld/Limits/releases/tag/1.29.1)
+
 ??? note "What's new in v1.29.0"
     **Released:** 2026-07-10
 

--- a/docs/gamemodes/AOneBlock/index.md
+++ b/docs/gamemodes/AOneBlock/index.md
@@ -4,7 +4,7 @@ One block. That's it. That's where you start.
 
 Mine it and it comes back as something else — a grass block, a tree, a chest, a mob. Mine it again. Keep going. Slowly, painstakingly, you build an island from nothing, unlocking new phases as you progress: Plains, Underground, Ocean, Jungle, Nether, and beyond. Each phase brings new blocks, new mobs, and new surprises. Some very hostile surprises.
 
-**AOneBlock** is BentoBox's take on IJAminecraft's beloved OneBlock map — rebuilt as a full multiplayer server experience with 11 themed phases, 11,000+ blocks of content, loot chests of varying rarity, and enough depth to keep players coming back for weeks.
+**AOneBlock** is BentoBox's take on IJAminecraft's beloved OneBlock map — rebuilt as a full multiplayer server experience with 20 themed phases, 15,000+ blocks of content, loot chests of varying rarity, and enough depth to keep players coming back for weeks.
 
 Created and maintained by [tastybento](https://github.com/tastybento).
 
@@ -34,6 +34,42 @@ The main `config.yml` file contains basic information about game-mode addon setu
 After addon is successfully installed, it will create a config.yml file. Every option in this file comes with comments about them. Please check file for more information.
 You can find the latest config file: [config.yml](https://github.com/BentoBoxWorld/AOneBlock/blob/develop/src/main/resources/config.yml)
 
+### The Phase Index — `phases_index.yml`
+
+!!! new "Added in AOneBlock 1.26.0"
+    `phases_index.yml` sits next to the `phases` folder and is the source of truth for which phases load, in what order, how long each one is, and which Minecraft version each one needs. It is read **before** any phase file is parsed, so a phase that needs a newer Minecraft version is skipped without its YAML — and any items inside it — ever being touched.
+
+Each entry in the `phases:` list takes these fields:
+
+| Field | Meaning |
+|---|---|
+| `file` | Base name of the phase file in the `phases` folder, without `.yml`. The chest file is `<file>_chests.yml`. |
+| `section` | The top-level key inside the phase file (historically the start block). |
+| `name` | Display name, used in logs and in the `/[admin_command] phases` panel. |
+| `length` | Number of blocks in the phase. |
+| `enabled` | Optional, defaults to `true`. Set `false` to leave a phase out. |
+| `requiredMinecraftVersion` | Optional. The phase is skipped — taking up no blocks at all — on servers older than this version. |
+
+Start blocks are **computed**: they are the running sum of the lengths of the enabled phases above, starting at 0. That means phases can be reordered freely and a skipped phase collapses out of the progression. After the last phase the block count jumps to `gotoAtEnd`.
+
+A top-level `adminLengths: true` is written automatically the first time you edit a length in `/[admin_command] phases`. From then on reconciliation never recomputes lengths, so your values survive later file additions, renames and upgrades.
+
+#### Reconciliation
+
+!!! note "Since 1.26.1 the phases folder is the source of truth"
+    The index is reconciled with the files actually on disk on every load, and on every save from the admin panel, so what `/[admin_command] phases` shows is what your server really runs. Watch the startup log for lines beginning `Phase index:` — they say exactly what was changed.
+
+- An entry whose file was **renamed across addon versions** is re-pointed at your file by phase name, so the phase loads again.
+- An entry whose file is **missing but shipped in the jar** is restored automatically. This is what makes new phases appear on upgraded servers, since files in `phases/` are never overwritten.
+- **Custom phase files** dropped into the folder are added automatically. A numeric key slots in at its legacy start block; anything else is appended at the end for you to arrange in the panel.
+- Entries whose files are gone for good are removed with a warning, so the panel never lists phases that do not exist.
+- When repair was needed, lengths are recomputed from your files' legacy start-block keys, preserving the layout your server actually ran before the index existed — unless `adminLengths` is set.
+
+!!! warning "Deleting a phase"
+    To remove a phase permanently, delete its files, or toggle it off in `/[admin_command] phases`. Deleting only its index entry does not work — reconciliation re-adds any phase file it finds in the folder.
+
+    A malformed index falls back to the old direct file loading, so a bad edit cannot leave the addon stuck.
+
 ### Phase Config Files
 
 The config files to make the phases are in the `phases` folder.
@@ -41,6 +77,9 @@ The config files to make the phases are in the `phases` folder.
 There are two files per phase - a file that contains the blocks and mobs, and a file that contains the chests.
 
 The first number of any file is how many blocks need to be mined to reach that phase. This is the phase's key number.
+
+!!! tip "Numbers in phase file names are optional since 1.26.1"
+    Custom phase files no longer need a numeric start block in the file name or as the YAML section key — `desert.yml` with a `desert:` section works. Chest files still pair by file name (`<file>_chests.yml`). The numbers in the shipped files are historical: with the index in charge, the panel's start and length values are the truth. Numeric keys remain useful because they tell reconciliation where a file belongs and how long it was.
 
 === "name"
     !!! summary "Description"
@@ -90,6 +129,23 @@ The first number of any file is how many blocks need to be mined to reach that p
         `biome` is an experimental option. However, it changes biome only for the "magic" block location. 
         So we would suggest to use the Biomes addon that has an option to change the biome on whole island. 
         You can do it with phase start commands which would trigger biome change.
+
+=== "requiredMinecraftVersion"
+    !!! summary "Description"
+        Since 1.26.0, a phase, a single block, or a single mob can declare the minimum Minecraft version it needs. Anything the server is too old for is skipped with a single info log line instead of throwing `Tried to load invalid item` or `ConfigurationSerialization` errors.
+
+        At the phase level the value belongs in `phases_index.yml` as well, so the phase can be skipped before its file is parsed at all. Set at the phase level, the phase takes up no blocks on an older server and the phases after it collapse up.
+
+        Individual `blocks` and `mobs` entries take an object form with `weight` plus their own `requiredMinecraftVersion`. Chest files are read item by item, so an item your server version does not know is skipped on its own and the rest of the chest still loads.
+
+    !!! example "Example"
+        ```yaml
+            blocks:
+              NETHERRACK: 300
+              DRIED_GHAST:
+                weight: 25
+                requiredMinecraftVersion: '1.21.6'
+        ```
 
 === "start-commands"
     !!! summary "Description"
@@ -348,6 +404,16 @@ You can find more information how BentoBox custom GUI's works here: [Custom GUI'
     - `/[admin_command] sanity [<phase>]`: sends a message if phases (or `<phase>`) chests are correct.
     - `/[admin_command] setcount <player> <number>`: allows changing the current phase to a `<player>` where `<number>` is the phase start number.
     - `/[admin_command] setchest <phase> <rarity>`: saves a chest that player is looking at into `<phase>` chests section with `<rarity>`.
+    - `/[admin_command] phases`: opens the phase order editor. (Since 1.26.0)
+
+    ??? tip "Using the phase order editor"
+        `/[admin_command] phases` shows every phase in order with its computed start block, length and state. It edits `phases_index.yml`, and drops and toggles save the index and reload the phases immediately.
+
+        - **Left-click** a phase to pick it up — the rest shrink left. Click where it should go to shove the others right and drop it, or use the drop-at-end slot. Click anywhere else, or close the panel, to put it back without saving.
+        - **Right-click** toggles a phase on or off.
+        - **Shift-left-click** sets a phase's length (since 1.26.1). The panel closes and a chat prompt shows the current length; type a whole number to apply it, or `cancel` to keep it. Invalid input re-prompts, and the prompt times out after 60 seconds. The first length edit writes `adminLengths: true` into the index so your values are never recomputed again.
+
+        Disabled phases show as gray glass and version-locked ones as barriers — both can still be reordered. A phase with no configured icon uses its first block.
 
 
 By default, BentoBox GameMode addons comes with the default sub-command set, however, each addon may introduce even more sub commands.
@@ -372,6 +438,7 @@ By default, BentoBox GameMode addons comes with the default sub-command set, how
     - `aoneblock.admin.sanity` - Let the player use the '/[admin_command] sanity' command. Default OP.
     - `aoneblock.admin.setchest` - Let the player use the '/[admin_command] setchest' command. Default OP.
     - `aoneblock.admin.setcount` - Let the player use the '/[admin_command] setcount' command. Default OP.
+    - `aoneblock.admin.phases` - Let the player use the '/[admin_command] phases' command to open the phase order editor. Default OP. (Since 1.26.0)
 
 By default, BentoBox GameMode addons comes with the default sub-permission set, however, each addon may introduce even more sub-permissions.
 
@@ -424,15 +491,17 @@ By default, BentoBox GameMode addons comes with [default placeholders set](../..
     Please add it to the list [here](https://github.com/BentoBoxWorld/AOneBlock/issues).
 
 ??? question "What phases are there?"
-    There are 11 phases: Plains, Underground, Winter, Ocean, Jungle, Swamp, Dungeon, Desert, The Nether, Plenty, Desolation, and The End. 
+    There are 20 shipped phases, in this order: Plains, Underground, Winter, Ocean, Jungle, Swamp, Dungeon, Desert, The Nether, Plenty, Desolation, Deep Dark, The End, Lush Caves, Dripstone Caves, Mangrove Swamp, Meadow, Cherry Grove, Jagged Peaks, and Sulfur Caves.
 
     Each phase features a set of blocks, items, and mobs appropriate for the setting.
 
-??? question "How many blocks are there in the 11 phases?"
-    There are currently 11 thousand blocks!
+    Sulfur Caves requires Minecraft 26.2 or later. On older servers it is skipped and Jagged Peaks runs to the loop point instead. You can reorder, disable and resize phases yourself with `/[admin_command] phases`, and add your own phase files to the `phases` folder.
+
+??? question "How many blocks are there in all the phases?"
+    15,500 blocks with the shipped phases on a Minecraft 26.2+ server, or 15,000 without the Sulfur Caves phase.
 
 ??? question "What happens after the last phase?"
-    The phases repeat.
+    The phases repeat — the block count jumps back to the `gotoAtEnd` value in `phases_index.yml`, which is 0 by default.
 
 ??? question "Why do I keep falling and dying!"
     There are tricks to surviving, but it might be difficult! You need to build defenses.
@@ -697,3 +766,62 @@ AOneBlock has some custom events that are called only in AOneBlock. But BentoBox
     - 🐛 **`my_island_*` placeholders fixed for visiting team members.** When a player who belongs to a team visited another island, the `my_island_*` placeholders resolved to the visited island's team data instead of the player's own island. They now always resolve to the player's own island.
 
     [Release v1.25.1](https://github.com/BentoBoxWorld/AOneBlock/releases/tag/1.25.1)
+
+??? note "What's new in v1.25.2"
+    **Released:** 2026-07-18
+
+    Bug-fix release — drop-in replacement, no config or locale changes.
+
+    - 🐛 **Jobs Reborn infinite-reward exploit closed.** When the `MAGIC_BLOCK` flag denied a player from breaking the magic block, plugins that listen for block breaks — such as Jobs Reborn — still saw the break as successful and paid out rewards. Because the block instantly respawns, a visitor could mine the same valuable block indefinitely for infinite job rewards. The denied break is now cancelled before other plugins process it.
+    - 🐛 **`actionbar: false` now actually disables the action bar.** If the boss bar was enabled, the action bar progress display kept showing even with `actionbar: false` set, and the same applied in reverse to the boss bar. Both settings are now respected, and the progress displays are no longer updated twice per block break when both are enabled.
+
+    [Release v1.25.2](https://github.com/BentoBoxWorld/AOneBlock/releases/tag/1.25.2)
+
+!!! warning "What's new in v1.26.0 — the phase index (review after upgrading)"
+    **Released:** 2026-07-20
+
+    Adds the Sulfur Caves phase for Minecraft 26.2 servers, and — because shipping a 26.2-only phase to an addon that also runs on 1.21.x needed real version handling — introduces the phase index that controls which phases load, in what order, and on which server versions. Compatibility: BentoBox API 3.15.0+ · Minecraft 1.21.5 or later · Java 21.
+
+    - **Sulfur Caves phase.** A new phase at the 15000 spot: sulfur and cinnabar layered through typical underground blocks, with Sulfur Cubes, cave spiders and friends at the wiki's spawn weights, plus themed chests that can drop the *Bounce* music disc. The end-of-game loop moves from 15000 to 15500. The phase declares `requiredMinecraftVersion: '26.2'`, so it appears automatically on 26.2+ servers and is skipped with a single info log on older ones — Jagged Peaks simply runs to the loop point instead.
+    - 🔺 **New `phases_index.yml`.** Now the source of truth for phase order, length, enabled state and required Minecraft version. Start blocks are the running sum of the lengths above, so phases can be moved freely and a skipped phase collapses out of the progression. The index is read **before** any phase file is parsed, which kills the `Tried to load invalid item` and `ConfigurationSerialization` stack traces that newer-version items used to cause on older servers. See the Configuration section above.
+    - **Version-gated blocks, mobs and chest items.** Chest files are now read item by item, so an item this server version does not know is skipped with one log line and the rest of the chest loads. Block and mob entries accept an object form with a per-entry `requiredMinecraftVersion`.
+    - 🔡 **New `/[admin_command] phases` panel** (permission `aoneblock.admin.phases`, OP by default) to reorder, insert and toggle phases by clicking them around an inventory panel.
+
+    🔺 **A `phases_index.yml` is generated on first start** from the phase files in your data folder, and from then on it controls phase order and lengths. Worth a quick review after the first boot, especially if you have hand-edited phases. A malformed index falls back to the old direct file loading, so nothing can get stuck.
+
+    🔺 **Existing installs do not get the new phase files automatically.** Files in `addons/AOneBlock/phases/` are never overwritten. On 1.26.0 you had to copy `15000_sulfur_caves.yml` and `15000_sulfur_caves_chests.yml` from the jar yourself; from 1.26.1 reconciliation restores them for you.
+
+    🔡 **New locale keys** were added for the phase order editor — regenerate or update translated locale files.
+
+    [Release v1.26.0](https://github.com/BentoBoxWorld/AOneBlock/releases/tag/1.26.0)
+
+!!! warning "What's new in v1.26.1 — the phases folder is now the source of truth"
+    **Released:** 2026-07-21
+
+    A bug-fix release for the 1.26.0 phase index. In 1.26.0 upgrading servers received the *stock* `phases_index.yml`, which references the current jar's file names — but existing `phases/` folders hold older or customized layouts. Phases silently failed to load, Sulfur Caves never appeared on upgraded servers, and `/[admin_command] phases` showed a preset instead of the server's reality.
+
+    - 🔺 **Self-healing phase index.** The index is now reconciled with the `phases/` folder on every load and on every panel save: entries renamed across addon versions are re-pointed at your file by phase name, entries missing but shipped in the jar are restored (so Sulfur Caves appears on upgraded 26.2 servers), custom phase files are added automatically, and entries whose files are gone for good are removed with a warning. Where repair was needed, lengths are recomputed from your files' legacy start-block keys, preserving the layout your server actually ran.
+    - 🔡 **Set phase lengths in the panel.** Shift-left-click a phase to set its length via a chat prompt. The first length edit writes `adminLengths: true` into `phases_index.yml`, after which reconciliation never recomputes lengths again.
+    - **Numbers in phase file names are now optional.** A custom `desert.yml` with a `desert:` section works; chest files still pair by file name.
+    - 🔡 **Panel polish.** Phase icons fall back to the phase's first block instead of stone, the "How to use" book wraps onto four lines, and the per-phase lore is shorter for small monitors.
+
+    🔺 **Your `phases_index.yml` will likely be rewritten on the first boot** to match the files in your phases folder. Watch the log for lines starting `Phase index:` — they say exactly what was re-pointed, restored, added or removed. Phases that vanished after the 1.26.0 upgrade come back on their own.
+
+    🔺 **To remove a phase permanently, delete its files,** or toggle it off in the panel. Deleting only its index entry no longer works — reconciliation re-adds any phase file it finds.
+
+    🔡 **New and changed locale keys** for the length prompt and the reworked panel text.
+
+    [Release v1.26.1](https://github.com/BentoBoxWorld/AOneBlock/releases/tag/1.26.1)
+
+??? note "What's new in v1.26.2"
+    **Released:** 2026-07-25
+
+    Bug-fix release for a loot regression introduced in 1.26.0. **If you are on 1.26.0 or 1.26.1, update.**
+
+    - 🐛 **Chest items keep their meta again.** Since 1.26.0 chest files have been read with plain SnakeYAML rather than `YamlConfiguration`, so that an item unknown to your server version can be skipped on its own instead of taking down the whole chest file. The side effect was that nothing was deserialized on the way in: an item's `meta` section arrived as a plain map, and Bukkit's item deserializer silently ignores meta that is not already an `ItemMeta`. Enchantments, potion effects and names were dropped without a line in the log — most visibly the enchanted books from the Plains chests, but it applied to every chest item in every phase, including potions, tipped arrows, custom-named items, banners, player heads and written books.
+
+        Chest item definitions are now walked properly and their meta is deserialized before the item is built. The 1.26.0 behaviour is unchanged — an item that does not exist on your Minecraft version is still skipped with a log line — and a meta section that cannot be read now costs only its meta, and says so in the log, rather than losing the item.
+
+    No phase file changes are needed: the old-style enchantment names in the shipped phase YAML (`PROTECTION_FALL` and friends) are still translated by the server, so customized chest files work as they are. Items players have **already** looted stay as they are — the meta was lost when the chest was filled, so there is nothing to repair after the fact. Every chest generated from now on is correct.
+
+    [Release v1.26.2](https://github.com/BentoBoxWorld/AOneBlock/releases/tag/1.26.2)

--- a/docs/gamemodes/AcidIsland/index.md
+++ b/docs/gamemodes/AcidIsland/index.md
@@ -55,6 +55,29 @@ The latest `config.yml` can be found [here](https://github.com/BentoBoxWorld/Aci
 
     Default: `true`
 
+### Sulfur ocean
+
+!!! new "Added in AcidIsland 2.0.0"
+    On Minecraft 26.2 and later the acid sea is acid-green sulfur water, dotted with bubbling sulfur vents that gas the surface with nausea and periodically erupt as geysers. The ocean floor is a weighted mix of sand, gravel, sandstone and tuff with bubbling magma blocks, plus scatterings of sulfur and cinnabar on 26.2+. The same jar still runs on Minecraft 1.21.x servers, where the 26.2 features disable themselves and the water falls back to the classic warm ocean.
+
+!!! warning "These are world generation settings"
+    All three options below bake in when a chunk is generated. BentoBox does not support changing them mid-game — existing chunks keep their current look, so expect a visible seam at old chunk borders unless you start a fresh world.
+
+??? note "world.default-biome"
+    The default biome for the overworld. `SULFUR_CAVES` (Minecraft 26.2+) gives acid-green water with matching green fog. On older servers that biome does not exist and `WARM_OCEAN` is used instead.
+
+    Default: `SULFUR_CAVES` (was `WARM_OCEAN` before 2.0.0)
+
+??? note "world.sulfur-vent-chance"
+    Chance (0–100) per chunk of a sulfur vent generating just below the sea surface. Vents are made of potent sulfur over a magma block and bubble, gas, and erupt as geysers. They come in four natural shapes — chimney, mound, twin and spiky crag — with random variation. Requires Minecraft 26.2 or later; ignored on older servers.
+
+    Default: `10`
+
+??? note "world.make-structures"
+    Generate vanilla structures in the worlds. Trial chambers and other underground structures generate buried beneath the ocean floor, giving players a reason to dig down, and making the trial key in the starter kit earnable.
+
+    Default: `true` (was `false` before 2.0.0)
+
 ## Permissions
 
 Permissions can be found [here](Permissions).
@@ -68,6 +91,35 @@ Commands can be found [here](Commands).
 Placeholders can be found [here](Placeholders).
 
 ## Changelog
+
+!!! warning "What's new in v2.0.0 — sulfur ocean (world generation changes)"
+    **Released:** 2026-07-20
+
+    AcidIsland embraces Minecraft 26.2's sulfur pools as the signature look of the acid ocean. Compatibility: BentoBox API 3.14.0 · Minecraft 1.21.11 – 26.2 (sulfur features require 26.2+) · Java 21.
+
+    - ⚙️ **Acid-green sulfur water.** The default overworld biome is now `SULFUR_CAVES`, turning all water acid-green with matching green fog. On servers older than 26.2 the biome does not exist and the world falls back to `WARM_OCEAN`.
+    - ⚙️ **Sulfur vents and geysers.** Potent sulfur vents generate just below the sea surface: bubbles, a nausea gas cloud on the surface, and periodic geyser eruptions, in four natural shapes with random variation. Per-chunk chance is set by the new `world.sulfur-vent-chance` option (default 10%); requires Minecraft 26.2+.
+    - **Varied ocean floor.** The barren sand floor is now a weighted mix of sand, gravel, sandstone and tuff with bubbling magma blocks, plus sulfur and cinnabar on 26.2+. Older servers get gravel and tuff in place of the 26.2 blocks.
+    - **New "Sulfur Spring Refuge" starter island.** A hardy spruce outcrop with leaf litter, eyeblossoms, a wither rose, podzol, a tuff sanctum below and a goat, with the same utilitarian starter kit as the cherry grove island. Built entirely from 1.21-safe blocks.
+    - ⚙️ **Structures on by default.** `world.make-structures` now defaults to `true`, so trial chambers and other underground structures generate buried beneath the ocean floor.
+
+    🔺 **World generation changes.** The new water biome, vents, ocean floor and structures all bake in at chunk generation. Existing worlds keep their current look in explored chunks; for the full 2.0.0 experience start a fresh world, or expect a visible seam at old chunk borders.
+
+    ⚙️ **Existing configs are not changed.** Your `config.yml` keeps its saved values. To adopt the new defaults on an existing install, set `default-biome: SULFUR_CAVES` and `make-structures: true`, add `sulfur-vent-chance: 10`, or delete the config to regenerate it.
+
+    🔺 **New blueprints on existing installs.** BentoBox only extracts bundled blueprints into a *missing* blueprints folder. To see the new island option on an existing install, copy `sulfur-spring.blueprint` and `sulfur_spring.json` from the jar into `plugins/BentoBox/addons/AcidIsland/blueprints/`.
+
+    [Release v2.0.0](https://github.com/BentoBoxWorld/AcidIsland/releases/tag/2.0.0)
+
+??? note "What's new in v1.22.1"
+    **Released:** 2026-06-28
+
+    Maintenance release. No configuration or locale changes are required.
+
+    - 🐛 **Duplicate permission keys in `addon.yml` fixed.** Several commands legitimately share one permission node — `/ai ban`, `/ai unban` and `/ai banlist` all use `acidisland.island.ban` — but they were written as separate YAML entries with identical keys. YAML keeps only the last of a duplicated key, so earlier permission descriptions were silently dropped and the server logged `duplicate keys found` on every load. Each shared node is now a single entry with a combined description, and the startup warnings are gone.
+    - Added Minecraft 26.2 (and backfilled 26.1.2) to the published game-versions list.
+
+    [Release v1.22.1](https://github.com/BentoBoxWorld/AcidIsland/releases/tag/1.22.1)
 
 ??? note "What's new in v1.22.0 — Purified water mechanic"
     **Released:** 2026-04-15


### PR DESCRIPTION
## Summary

Documentation updates triggered by new releases detected since the last run (2026-07-11):

| Repo | Previous | New |
|---|---|---|
| BentoBox | 3.20.0 | 3.21.0 |
| AcidIsland | 1.22.0 | 1.22.1, **2.0.0** |
| AOneBlock | 1.25.1 | 1.25.2, 1.26.0, 1.26.1, **1.26.2** |
| ExtraMobs | *(untracked)* | 1.15.0 |
| Greenhouses | 1.9.5 | 1.9.6, **1.10.0** |
| Limits | 1.29.0 | 1.29.1 |

No new flags or placeholders were introduced, so `data/flags.csv` and `data/placeholders.csv` are unchanged.

## Changes per repo

### BentoBox (3.20.0 → 3.21.0)
- `About/AdminTools.md`: new 3.21.0 changelog entry covering the `island.dialogs` config section (`confirmations`, `go-picker`, `team-invites` on; `game-mode-selection` off) and the locale note; demoted 3.20.0 to a collapsed entry.
- `About/IslandManagement.md`: new **Finding the right home** subsection documenting the forgiving `/island go <name>` resolution order (exact → case/colour/whitespace-insensitive → unique prefix) and the `go-picker` destination dialog.
- `About/Teams.md`: new **Invite dialogs** subsection for the `team-invites` and `confirmations` toggles.
- `Developer-Documentation.md`: new **Modal dialogs** section documenting the `world.bentobox.bentobox.api.dialogs` API (`Dialogs.isSupported()`, `DialogBuilder`, `DialogButton`, `BBDialog`) with a worked example and the fallback requirement.

### AcidIsland (1.22.0 → 2.0.0)
- New **Sulfur ocean** configuration subsection: `world.default-biome` (now `SULFUR_CAVES`), `world.sulfur-vent-chance` (new, default 10), `world.make-structures` (default flipped to `true`), with a warning that all three are world-generation settings.
- Changelog entries for 2.0.0 (as a `!!! warning` — world generation changes, configs not auto-updated, blueprints not auto-extracted) and 1.22.1.

### AOneBlock (1.25.1 → 1.26.2)
- New **The Phase Index — `phases_index.yml`** configuration section: field table, computed start blocks, `adminLengths`, and the 1.26.1 reconciliation rules plus the "delete the files, not the index entry" warning.
- New `requiredMinecraftVersion` tab documenting phase-, block- and mob-level version gating with the `DRIED_GHAST` object-form example.
- Added `/[admin_command] phases` to the admin commands tab with a how-to-use tip (left/right/shift-left click, drop-at-end, gray glass vs barriers), and `aoneblock.admin.phases` to admin permissions.
- Corrected the phase count throughout: 20 shipped phases and 15,500 blocks (15,000 without the 26.2-only Sulfur Caves phase) — the page said 11 phases / 11,000 blocks while listing 12 names.
- Changelog entries for 1.25.2, 1.26.0, 1.26.1 and 1.26.2.
- Note: 1.26.0/1.26.1 are `!!! warning` (expanded) because both rewrite `phases_index.yml` on first boot.

### ExtraMobs (untracked → 1.15.0)
- Added a **Configuration** section — the page had none. Documents `disabled-gamemodes`, `nether-chances`, `end-chances`, `overworld-chance` and the new `gamemode-settings` block, including the per-GameMode rule format, evaluation order, and global fallback behaviour.
- Refreshed **Compatibility** from the stale "BentoBox 1.11.0 / Minecraft 1.15.2" to BentoBox 3.14.0+, Paper 1.21.x, Java 21+.
- Added a Changelog section with the 1.15.0 entry.

### Greenhouses (1.9.5 → 1.10.0)
- Rewrote **Admin Commands** with the real 1.10.0 tree (`list`, `info`, `delete`, `tp`, `verify`, `reload`) including ID-prefix matching, console support, and how unloadable records are retained; added an overlap-cleanup tip.
- Corrected **Player Commands**: removed `greenhouses list` and `greenhouses recipe`, which were never registered (unreachable stubs, deleted in 1.10.0), with a warning explaining the correction.
- `Permissions.md`: added the six `greenhouses.admin.*` nodes and the `greenhouses.biome.nether` row.
- Changelog entries for 1.9.6 and 1.10.0.

### Limits (1.29.0 → 1.29.1)
- Changelog entry only (natural-breeding limit enforcement, breeding cooldown/spam suppression, tracking-map leak, boats in `recount`). No config or locale changes in this release.

## Verification

- [x] `mkdocs build --strict` passes with exit code 0 and zero warnings (run with `GITHUB_TOKEN` set — the `translations()` macro otherwise hits the unauthenticated GitHub rate limit and emits 403 warnings)
- [x] All new cross-page links and anchors verified against the built HTML: `IslandManagement.md#home-locations`, `Developer-Documentation.md#modal-dialogs`, `index.md#permissions`
- [x] Release details verified against the tagged source, not `develop` — the local AcidIsland clone is ahead of `2.0.0`, so unreleased options (e.g. `erupt-on-offering`) were deliberately excluded
- [x] Config keys, defaults and descriptions taken from each repo's `config.yml` at the release tag; permissions from `addon.yml`; Greenhouses command labels and aliases from the registered command classes

🤖 Generated with [Claude Code](https://claude.com/claude-code) using the `update-docs` skill

https://claude.ai/code/session_01USq9LzpqUk3GUtWbsXmcby