### PR TITLE
docs: add DeathChest to the homepage addon list

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -134,6 +134,7 @@ hide:
     <a href="addons/Chat/" class="bb-chip">Chat</a>
     <a href="addons/CheckMeOut/" class="bb-chip">CheckMeOut</a>
     <a href="addons/ControlPanel/" class="bb-chip">ControlPanel</a>
+    <a href="addons/DeathChest/" class="bb-chip">DeathChest</a>
     <a href="addons/DimensionalTrees/" class="bb-chip">DimensionalTrees</a>
     <a href="addons/ExtraMobs/" class="bb-chip">ExtraMobs</a>
     <a href="addons/FarmersDance/" class="bb-chip">FarmersDance</a>


### PR DESCRIPTION
The DeathChest addon page (`docs/addons/DeathChest/index.md`) and its `mkdocs.yml` nav entry already exist, but the addon was missing from the chip list in the Addons section of the homepage.

Adds a `DeathChest` chip in alphabetical order, between ControlPanel and DimensionalTrees.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019RXk7GZJKreEL42NRYBwV7