### PR TITLE
docs: update documentation for releases 2026-08-01

### DIFF
--- a/data/release-tracker.json
+++ b/data/release-tracker.json
@@ -1,9 +1,9 @@
 {
-  "last_run": "2026-07-27T15:02:00Z",
+  "last_run": "2026-08-01T14:34:14Z",
   "repos": {
     "BentoBox": {
-      "last_checked": "2026-07-26T04:16:18Z",
-      "last_release": "3.21.0",
+      "last_checked": "2026-08-01T14:34:14Z",
+      "last_release": "3.22.0",
       "doc_path": "BentoBox/",
       "category": "core"
     },
@@ -14,8 +14,8 @@
       "category": "gamemode"
     },
     "AOneBlock": {
-      "last_checked": "2026-07-26T04:16:18Z",
-      "last_release": "1.26.2",
+      "last_checked": "2026-08-01T14:34:14Z",
+      "last_release": "1.26.3",
       "doc_path": "gamemodes/AOneBlock/index.md",
       "category": "gamemode"
     },
@@ -74,8 +74,8 @@
       "category": "addon"
     },
     "Border": {
-      "last_checked": "2026-06-01T01:05:19Z",
-      "last_release": "4.8.4",
+      "last_checked": "2026-08-01T14:34:14Z",
+      "last_release": "4.8.5",
       "doc_path": "addons/Border/index.md",
       "category": "addon"
     },
@@ -140,8 +140,8 @@
       "category": "addon"
     },
     "Level": {
-      "last_checked": "2026-05-23T00:37:17Z",
-      "last_release": "2.27.0",
+      "last_checked": "2026-08-01T14:34:14Z",
+      "last_release": "2.28.1",
       "doc_path": "addons/Level/index.md",
       "category": "addon"
     },
@@ -188,8 +188,8 @@
       "category": "addon"
     },
     "Warps": {
-      "last_checked": "2026-05-23T00:37:17Z",
-      "last_release": "1.19.0",
+      "last_checked": "2026-08-01T14:34:14Z",
+      "last_release": "1.19.1",
       "doc_path": "addons/Warps/index.md",
       "category": "addon"
     },

--- a/docs/BentoBox/About/AdminTools.md
+++ b/docs/BentoBox/About/AdminTools.md
@@ -105,7 +105,27 @@ This reloads BentoBox and all addons, including locales. Note that some changes 
 
 ## Changelog
 
-!!! note "What's new in v3.21.0 — modal dialogs"
+!!! note "What's new in v3.22.0 — Brigadier commands"
+    **Released:** 2026-08-01
+
+    A commands-and-visibility release. Compatibility: Paper Minecraft 1.21.5 – 26.2, Java 25+.
+
+    - ⚙️ 🔺 **Commands are registered with Paper's Brigadier API.** Players now see BentoBox subcommands and completions *as they type* — `/island t…` offers `team` in the chat bar — instead of the client knowing nothing until enter or TAB. The subcommand tree is advertised to a depth of 4; deeper subcommands still work, they just are not pre-advertised. Aliases and the `plugin:label` form are sent as redirects rather than duplicated trees. A new `general.brigadier-commands` option in `config.yml` defaults **on**; set it to `false` and `/bbox reload` to fall back to the legacy command map if another plugin conflicts. BentoBox also falls back automatically if it cannot hook the registrar.
+    - 🔺 **Structure searches are suppressed automatically in worlds that generate no structures.** A cartographer rolling an explorer-map trade — or an Eye of Ender, dolphin or treasure map — used to run a synchronous structure search that could never succeed in a void world, scanning to the radius cap and blowing past the 60-second watchdog. BentoBox now asks the world's generator whether it places structures at all and skips the search if it does not, with **no configuration needed**. AOneBlock and BSkyBlock get this automatically; SkyGrid, Boxed, CaveBlock and AcidIsland are unaffected because they do generate structures. A per-world `structures` entry of `true` still force-enables a structure, as an escape hatch for converted worlds that contain pre-existing ones. This complements the opt-in `world.disabled-structures` list added in 3.20.0.
+    - **`/island settings` now opens out in the world.** Players away from any island, or in a game mode where they never own one, used to get "You do not have an island!". The panel now opens with a read-only **World Protections** tab showing which protection flags are active for the world — which is exactly what governs them where they are standing. See [Protection](Protections.md#viewing-the-world-rules-off-island).
+    - 🐛 **Addon data queued during shutdown is no longer discarded.** Anything an addon saved from `onDisable()` was queued into a database pipeline that had already stopped draining, so it was silently, intermittently lost on every restart. Nine bundled addons save on disable — Boxed, AOneBlock, Raft, Challenges, Limits, DragonFights, CheckMeOut, ControlPanel and InvSwitcher — and with InvSwitcher the stale stored inventory was then re-applied on join, making it a rollback rather than just a lost write. Shutdown writes are now drained before the database closes.
+    - 🐛 **BentoBox commands work from NPCs, signs and GUI plugins again.** Brigadier registration had taken BentoBox commands out of the Bukkit command map that other plugins dispatch through, so an NPC running `/oneblock go` answered with the server's no-permission message and ran nothing. Commands are now registered with the command map as well. This only ever affected 3.22.0 development builds.
+    - 🐛 **`Island.setFlag` no longer discards writes.** Setting a protection rank on an island that had no entry yet for that flag — which is every freshly created island — silently did nothing. `SETTING` and `WORLD_SETTING` flags were unaffected.
+    - 🐛 **Repeated warnings stay throttled.** A player alternating between two different limit messages bypassed the 4-second notification cooldown entirely. Each distinct message is now throttled independently.
+    - 🐛 **BlueMap marker sets stay in their own worlds.** An addon's marker set no longer appears in the sidebar of every other map on the server, and `createMarkerSet()` / `removeMarkerSet()` no longer throw during a `/bluemap reload`.
+    - 🐛 **Multiverse tidy-up.** BentoBox worlds now get `auto-load: false` even when Multiverse already knew about them, and the dead seed-world (`<world>/bentobox`) registration is gone. Existing stale entries still need `/mv remove`.
+    - 🐛 **Flags from addons dropped for missing dependencies are cleaned up.** An addon whose hard dependency was absent had already registered its flags and listeners before being dropped, leaving listeners firing for a world that never existed.
+    - **Six new bStats charts** report addon and game mode versions, addon API levels, settings changed away from their defaults, and how and where commands fail. Only the failure kind and a stable permission-derived command key are submitted — never arguments or player names.
+    - 🔡 **Traditional Chinese (`zh-TW`) locale** added, contributed by @qwe664. No existing locale keys changed, so custom locale files need no work.
+
+    [Release v3.22.0](https://github.com/BentoBoxWorld/BentoBox/releases/tag/3.22.0)
+
+??? note "What's new in v3.21.0 — modal dialogs"
     **Released:** 2026-07-22
 
     A player-experience release. Compatibility: Paper Minecraft 1.21.5 – 26.2, Java 25+.

--- a/docs/BentoBox/About/Protections.md
+++ b/docs/BentoBox/About/Protections.md
@@ -78,6 +78,14 @@ Island owners open the settings GUI with `/island settings`. Admins can hide ind
 | **Leaf decay** | Whether leaf blocks decay naturally when logs are removed. |
 | **Mob spawning** | Whether monsters or animals can spawn on the island, including from spawner blocks. |
 
+### Viewing the World Rules Off-Island
+
+Since BentoBox 3.22.0, `/island settings` also works when the player is not standing on an island and does not own one — out in the wilderness, or in a game mode where players never own islands at all.
+
+In that case the panel opens with a single read-only **World Protections** tab listing each protection flag as active or disabled for the world. That is what actually governs a player off-island: with no island underneath them, a protection flag resolves to the world's on/off switch rather than to any rank. Nothing is clickable, and the island settings tab is not shown, since there is no island to configure.
+
+Players who are on or own an island see exactly the panel they always did.
+
 ## World Settings Admins Control
 
 These settings apply to the whole game mode world. Only admins can change them, via `/[admin_command] settings`. Players can view (but not change) these in a read-only mode so they understand the server rules.

--- a/docs/addons/Border/index.md
+++ b/docs/addons/Border/index.md
@@ -36,11 +36,23 @@ Created and maintained by [tastybento](https://github.com/tastybento).
 **Permission**: `[gamemode].border.type`. Default: `true`.  
 **Example**: `/[player command] border type barrier`  
 
+### bordertype {...}
+**Command**: `/[player command] bordertype {barrier | vanilla}`  
+**Description**: The same command as `border type`, registered directly under the game mode command.  
+**Permission**: `[gamemode].border.bordertype`. Default: `false`.  
+**Example**: `/[player command] bordertype vanilla`  
+
 ### border color {red|green|blue}
-**Command**: `/[player command] border color {red | green | blue}`  
+**Command**: `/[player command] border color {red | green | blue}` (also available as `/[player command] bordercolor {red | green | blue}`)  
 **Description**: Sets the vanilla world border color for the player. Only applies when using the vanilla border type.  
-**Permission**: `[gamemode].border.color.red`, `[gamemode].border.color.green`, `[gamemode].border.color.blue` (or `[gamemode].border.color.*` for all). Default: `op`.  
+**Permission**: `[gamemode].border.color` to run the command at all. Default: `true`.  
+Each colour then needs its own permission: `[gamemode].border.color.red`, `[gamemode].border.color.green`, `[gamemode].border.color.blue` (or `[gamemode].border.color.*` for all). Default: `op`.  
 **Example**: `/[player command] border color green`  
+
+!!! warning "Permission changes in 4.8.5"
+    `[gamemode].border.color` was never declared before 4.8.5, so it silently fell back to op-only and ordinary players could not run the colour command at all. It is now declared with a `true` default.
+
+    The declared node `[gamemode].bordertype` was also renamed to `[gamemode].border.bordertype`, which is the node the command really checks. If you granted or denied `[gamemode].bordertype` in LuckPerms (or similar), update the rule — the old node never had any effect.
 
 !!! tip
     `[gamemode]` is a prefix that differs depending on the gamemode you are running.
@@ -263,6 +275,20 @@ barrier-offset: 0
     No config or locale changes are required. If you worked around the bug with `bordertype barrier`, you can switch back to `vanilla` once 4.8.4 is installed.
 
     [Release v4.8.4](https://github.com/BentoBoxWorld/Border/releases/tag/4.8.4)
+
+??? warning "What's new in v4.8.5 — permission changes"
+    **Released:** 2026-08-01
+
+    A compatibility and permissions patch. No config or locale changes are required.
+
+    - 🐛 **Death drops are no longer hijacked from other plugins.** The death-drop protection added in 4.7.0 pulled every item out of `PlayerDeathEvent`, spawned them by hand and cleared the list — so DeathChest, grave plugins and keep-inventory features ran later and saw an empty event, with the items already on the ground. With the default `bounce-back: true` that silently broke all of them. Border now leaves the event's drops alone, runs at MONITOR priority, and bounces back only the items the server itself spawns near the death spot on the following tick. If another plugin takes the drops, nothing is bounced; if they survive, they bounce back exactly as before, keeping vanilla velocities and despawn timers.
+    - 🔺 **`[gamemode].border.color` is now declared with a `true` default,** so ordinary players can use the colour command as documented. It was never declared in `addon.yml` before, so it fell back to op-only. The individual colours (`.red`, `.green`, `.blue`) remain `op`. If you granted these explicitly to work around the bug, those grants still work.
+    - 🔺 **`[gamemode].bordertype` renamed to `[gamemode].border.bordertype`,** which is the node `BorderTypeCommand` actually checks. Its `false` default is unchanged. Update any LuckPerms rule referencing the old node — it never had any effect either way.
+    - Releases are now published automatically to CurseForge and Hangar alongside Modrinth, and the Modrinth listing covers 1.21.5 – 1.21.11 and 26.1.x.
+
+    Compatibility: BentoBox API 3.12.0+, Minecraft 1.21.5 – 1.21.11 and 26.1.x, Java 21.
+
+    [Release v4.8.5](https://github.com/BentoBoxWorld/Border/releases/tag/4.8.5)
 
 ## Translations
 

--- a/docs/addons/Level/index.md
+++ b/docs/addons/Level/index.md
@@ -185,6 +185,12 @@ This section defines values for blocks and limits for them.
 
     Format: `MATERIAL: NUMBER`
 
+    Since Level 2.28.0 these limits also apply to **donated** blocks, so a player cannot earn points past a block's cap by donating instead of placing:
+
+    - The level calculation caps each donated block type at its current limit. If you lower a limit after players have donated, only up to the new limit counts.
+    - `/[player_command] donate hand`, `/[player_command] donate inv` and the donation panel all check the limit up front, trimming the confirm prompt to the amount that will actually count (with a warning line when trimmed) and refusing outright when everything offered is already at its limit.
+    - Limit lookups are case-insensitive, so mixed-case custom block IDs (e.g. Oraxen items) resolve the same limit everywhere.
+
 ??? note "blocks"
     This section lists the value of a block in all game modes (worlds). 
     To specific world-specific values, use the next section. 
@@ -336,6 +342,9 @@ You can find more information how BentoBox custom GUI's works here: [Custom GUI'
     - `/[player_command] donate hand [amount]`: donates the item currently held in the player's hand (or the specified amount of it) directly to island level without opening the GUI. Requires `[gamemode].island.level.donate` permission.
     - `/[player_command] donate inv`: lists every donatable block in the player's inventory with per-material values and a running total, then on confirm donates them all and runs a level recalc. Items with no configured value and non-blocks stay in the inventory. Requires `[gamemode].island.level.donate` permission.
 
+    !!! note
+        Since 2.28.0, all three donation paths respect the block `limits` set in [`blockconfig.yml`](#blockconfigyml), and donated points are recalculated from current block values on every recalculation.
+
 
 === "Admin commands"
     - `/[admin_command] level <player>`: triggers level calculation for player. Requires `[gamemode].admin.level` permission.
@@ -485,6 +494,34 @@ You can find more information how BentoBox custom GUI's works here: [Custom GUI'
     🔡 **Locales updated.** All 18 shipped locales gained new `island.donate.inv.*` keys (`keyword`, `confirm-header`, `confirm-line`, `confirm-total`). If you have customised locale files in `plugins/BentoBox/addons/Level/locales/`, copy the new `donate.inv` block into them or the new `/island donate inv` flow will show raw keys.
 
     [Release v2.27.0](https://github.com/BentoBoxWorld/Level/releases/tag/2.27.0)
+
+??? warning "What's new in v2.28.0 — action required"
+    **Released:** 2026-07-28
+
+    Compatibility: BentoBox API 3.16.0, Minecraft 1.21.x and 26.1.x, Java 21.
+
+    - 🔺 **Donation limits are enforced end-to-end.** Block limits defined in [`blockconfig.yml`](#blockconfigyml) now apply everywhere donations are involved. The level calculation caps each donated block type at its current limit, and `/island donate hand`, `/island donate inv` and the donation GUI all check the limit up front — trimming the confirm prompt to the amount that will actually count, skipping materials already at their cap, and showing a clear "donation limits reached" message instead of a misleading 0-point prompt. Admin level reports cap donated lines at the current limit (marked "capped at N") so they sum to the donated total.
+    - **Donated points now follow current block values.** Points are recomputed from the stored donated-blocks map using current (and world-specific) values on every recalculation, so changing a value in `blockconfig.yml` applies retroactively instead of using a stale stored total. The donation GUI's "Currently donated" figure shows the same effective points the level uses.
+    - Limit lookups are case-insensitive, so mixed-case custom block IDs (e.g. Oraxen items) resolve the same limit everywhere.
+    - Releases now publish automatically to CurseForge and Hangar alongside Modrinth, and Minecraft 26.1.2 was added to the supported versions.
+
+    🔺 **Island levels may drop after upgrading** on servers where players donated past a block's limit — those blocks are now excluded from the level calculation. This is the intended fix, but be ready for questions.
+
+    🔡 **Locales updated.** All 17 shipped locales gained three new keys under `island.donate` (`limit-reached`, `limit-notice`, `limit-reached-all`). If you have customised locale files in `plugins/BentoBox/addons/Level/locales/`, add these keys or the limit warnings will show raw keys.
+
+    !!! note "Dev-build users"
+        The experimental per-chunk zeroing engine that appeared in snapshot builds during this cycle was removed before release and is **not** part of 2.28.0. Stable-release users are unaffected.
+
+    [Release v2.28.0](https://github.com/BentoBoxWorld/Level/releases/tag/2.28.0)
+
+??? note "What's new in v2.28.1"
+    **Released:** 2026-07-29
+
+    Bug-fix release — drop-in replacement for 2.28.0, with no locale, config or panel changes.
+
+    - 🐛 **The value panel's search button no longer stacks duplicate chat prompts.** Every click started another 90-second "Please enter a search value" conversation. If the first prompt was not visible — for example when a chat-managing plugin such as CMI swallowed it — players clicked repeatedly, stacking conversations that later replayed as alternating `Conversation cancelled!` / `Please enter a search value` spam with the GUI re-opening each time. The search input now repeats the question when a conversation is already pending instead of queueing a second one.
+
+    [Release v2.28.1](https://github.com/BentoBoxWorld/Level/releases/tag/2.28.1)
 
 ## Translations
 

--- a/docs/addons/Warps/index.md
+++ b/docs/addons/Warps/index.md
@@ -196,6 +196,19 @@ You can find more information how BentoBox custom GUI's works here: [Custom GUI'
 
     [Release v1.19.0](https://github.com/BentoBoxWorld/Warps/releases/tag/1.19.0)
 
+??? note "What's new in v1.19.1"
+    **Released:** 2026-07-30
+
+    Patch release — no config or locale changes are required.
+
+    - 🐛 **Sign owners are notified when a warp falls back to the sign block.** When no safe spot exists in front of a warp sign — common where signs sit at a platform edge with void in front — visitors were silently teleported onto the sign's own block: no `WarpInitiateEvent`, no vanish check, and no "X warped to your warp sign!" message for the owner. The fallback now runs through the same completion path as a normal warp, so events, vanish handling, sound and the owner notification behave identically wherever the visitor lands. The arrival yaw also now matches the sign's facing.
+    - Publishing to CurseForge and Hangar is now automated alongside the existing Modrinth workflow, and MC 26.1.2 was added to the Modrinth game-versions list.
+    - `addon.yml` API version bumped to 3.12.0, with additional softdepend entries for better load ordering.
+
+    Compatibility: BentoBox API 3.12.0+, Minecraft 1.21.x, Java 21.
+
+    [Release v1.19.1](https://github.com/BentoBoxWorld/Warps/releases/tag/1.19.1)
+
 ## Translations
 
 {{ translations("Warps") }}

--- a/docs/gamemodes/AOneBlock/index.md
+++ b/docs/gamemodes/AOneBlock/index.md
@@ -825,3 +825,14 @@ AOneBlock has some custom events that are called only in AOneBlock. But BentoBox
     No phase file changes are needed: the old-style enchantment names in the shipped phase YAML (`PROTECTION_FALL` and friends) are still translated by the server, so customized chest files work as they are. Items players have **already** looted stay as they are — the meta was lost when the chest was filled, so there is nothing to repair after the fact. Every chest generated from now on is correct.
 
     [Release v1.26.2](https://github.com/BentoBoxWorld/AOneBlock/releases/tag/1.26.2)
+
+??? note "What's new in v1.26.3"
+    **Released:** 2026-07-29
+
+    Bug-fix release for the phases GUI — drop-in replacement, with no config, locale or phase file changes.
+
+    - 🐛 **"Click to change" is only offered when the click can succeed.** The `/[player_command] phases` panel decided whether to offer the phase-change action from island state and phase requirements alone, and never checked whether the player held the `aoneblock.island.setcount` permission that the click actually uses. On servers where that permission is negated for some or all ranks, players saw the tooltip on every eligible phase and got *"You don't have the permission to execute this command"* when they clicked. The panel now checks the permission before offering the action. If the subcommand cannot be resolved for any reason the panel stays permissive as before, so no phase becomes unclickable because of this change. Players who **do** hold the permission see no difference.
+
+    Compatibility: BentoBox API 3.15.0+, Minecraft 1.21.5 or later (the Sulfur Caves phase itself activates on Minecraft 26.2+), Java 21.
+
+    [Release v1.26.3](https://github.com/BentoBoxWorld/AOneBlock/releases/tag/1.26.3)


### PR DESCRIPTION
## Summary

Documentation updates triggered by new releases detected since the last run (2026-07-27):

| Repo | Previous | New |
|---|---|---|
| BentoBox | 3.21.0 | 3.22.0 |
| AOneBlock | 1.26.2 | 1.26.3 |
| Border | 4.8.4 | 4.8.5 |
| Level | 2.27.0 | 2.28.1 (via 2.28.0) |
| Warps | 1.19.0 | 1.19.1 |

## Changes per repo

### BentoBox (3.21.0 → 3.22.0)
- Added a `What's new in v3.22.0 — Brigadier commands` changelog entry to `BentoBox/About/AdminTools.md`, covering the new `general.brigadier-commands` config option, automatic structure-search suppression in structureless worlds, the shutdown-write data-loss fix, the command-map regression fix, `Island.setFlag`, notification throttling, BlueMap marker scoping, Multiverse tidy-up, the new bStats charts and the `zh-TW` locale. Demoted 3.21.0 from `!!!` to `???` so only the newest entry is expanded.
- Added a **Viewing the World Rules Off-Island** section to `BentoBox/About/Protections.md` documenting that `/island settings` now opens a read-only World Protections tab when the player is not on and does not own an island, and linked to it from the changelog entry.

### AOneBlock (1.26.2 → 1.26.3)
- Added a `What's new in v1.26.3` changelog entry for the phases GUI fix — "Click to change" is now only offered to players who hold `aoneblock.island.setcount`.

### Border (4.8.4 → 4.8.5)
- **Corrected the Commands section permissions**, which were wrong/incomplete against `addon.yml`:
  - `border color` now documents `[gamemode].border.color` (default `true`) as the permission to run the command, with the per-colour `.red`/`.green`/`.blue` nodes (default `op`) on top, and notes the `/[player command] bordercolor` alias.
  - Documented the separate `/[player command] bordertype` command and its `[gamemode].border.bordertype` permission (default `false`), which was previously undocumented.
  - Added a `!!! warning` covering the 4.8.5 permission rename from `[gamemode].bordertype` to `[gamemode].border.bordertype`.
- Added a `What's new in v4.8.5 — permission changes` changelog entry covering the death-drop hijacking fix (DeathChest / grave plugin compatibility) and both permission changes.

### Level (2.27.0 → 2.28.1)
- Documented donation limit enforcement under the `limits` block in the `blockconfig.yml` section — limits now cap donated blocks in the level calculation and in all three donation paths, and lookups are case-insensitive.
- Added a note under the player commands tab pointing at `blockconfig.yml` limits and the recalculation-from-current-values behaviour.
- Added `What's new in v2.28.0 — action required` (with the 🔺 warning that island levels may drop, and the 🔡 note about the three new `island.donate` locale keys) and `What's new in v2.28.1` (duplicate search conversations in the value GUI).

### Warps (1.19.0 → 1.19.1)
- Added a `What's new in v1.19.1` changelog entry for the sign-block fallback warp now firing `WarpInitiateEvent`, the vanish check, sound and the owner notification.

### Tracker
- `data/release-tracker.json` updated with the new `last_release` tags and timestamps.

No new flags or placeholders were introduced by these releases, so `data/flags.csv` and `data/placeholders.csv` are unchanged.

## Verification

- [x] `mkdocs build --strict` passes with zero warnings (with `GITHUB_TOKEN` set — without it the `translations()` macro hits the unauthenticated GitHub rate limit and warns for every addon)
- [x] The two new in-page links (`#blockconfigyml`, `Protections/#viewing-the-world-rules-off-island`) verified to resolve against generated anchors in the built site

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019BGqnTSzBmQcccy61X3dVz