### PR TITLE
docs: add ChunkBlock and TradeWinds to the homepage and game mode indexes

### DIFF
--- a/docs/BentoBox/About/Addons.md
+++ b/docs/BentoBox/About/Addons.md
@@ -30,6 +30,7 @@ These create the world your players actually play in. Install at least one.
 | **Boxed** | A box that grows as you complete advancements |
 | **Poseidon** | Underwater survival |
 | **StrangerRealms** | Survival with a dangerous mirrored dimension |
+| **TradeWinds** | Sea trading across an endless ocean of NPC ports (requires Vault) |
 
 See [Game Modes](GameModes.md) for full descriptions, or [compare them](../../gamemodes/Comparison.md) to help pick one.
 

--- a/docs/BentoBox/About/Addons.md
+++ b/docs/BentoBox/About/Addons.md
@@ -24,6 +24,7 @@ These create the world your players actually play in. Install at least one.
 |---|---|
 | **BSkyBlock** | Classic Skyblock — floating island in the sky |
 | **AOneBlock** | Start from a single magical regenerating block |
+| **ChunkBlock** | One block in a walled chunk — spend island levels to claim more (requires Level) |
 | **AcidIsland** | Skyblock where the ocean is acid |
 | **CaveBlock** | Survival in a solid underground world |
 | **SkyGrid** | Scattered single blocks across the void |

--- a/docs/BentoBox/About/GameModes.md
+++ b/docs/BentoBox/About/GameModes.md
@@ -27,6 +27,14 @@ Players start with a single magical block floating in the void. Every time they 
 
 ---
 
+### ChunkBlock — One Block in a Walled Chunk
+
+Players start on the same magical regenerating block as AOneBlock, but the world is a single 16×16 chunk with a border nothing can cross — not walking, flying, pearling or digging. Island level is the currency for territory: build the level up, walk to the wall and punch it in the direction you want, and the next chunk opens. Lose levels and the newest chunks re-lock (builds untouched) until the levels come back. Requires the [Level](../../addons/Level/index.md) addon.
+
+**Best for:** Servers that want the one-block loop with a hard reason to keep levelling, and expansion the players earn a chunk at a time.
+
+---
+
 ### AcidIsland — Survival in Acid
 
 Similar to Skyblock, but the ocean surrounding the islands is filled with acid that damages players. Swimming is dangerous, so players must build carefully and avoid falling in.

--- a/docs/BentoBox/About/GameModes.md
+++ b/docs/BentoBox/About/GameModes.md
@@ -75,6 +75,14 @@ Players survive in an Overworld while managing an eerie mirror dimension — the
 
 ---
 
+### TradeWinds — Sea Trading
+
+Players start with a rowing boat and a little coal on an endless, procedurally generated ocean scattered with NPC trading islands. The boat is the cargo hold: buy low at one port, sell high at another, upgrade the hull, chart new islands to climb the Seafarer ranks, and eventually claim an islet of your own. Requires Vault and an economy plugin.
+
+**Best for:** Servers that want an economy-driven trading game — safe waters near spawn suit casual players, while smuggling, pirates, and PvP bounties wait further out.
+
+---
+
 ## Installing a Game Mode
 
 Game modes are downloaded as `.jar` files and placed in:

--- a/docs/BentoBox/Translate-BentoBox-and-addons.md
+++ b/docs/BentoBox/Translate-BentoBox-and-addons.md
@@ -67,6 +67,7 @@ island-go: "[sound:entity_experience_orb_pickup:1:1][title]Teleporting...[subtit
 - [Poseidon](../gamemodes/Poseidon/index.md#translations)
 - [SkyGrid](../gamemodes/SkyGrid/index.md#translations)
 - [Stranger Realms](../gamemodes/StrangerRealms/index.md#translations)
+- [TradeWinds](../gamemodes/TradeWinds/index.md#translations)
 
 ## Addons
 

--- a/docs/BentoBox/Translate-BentoBox-and-addons.md
+++ b/docs/BentoBox/Translate-BentoBox-and-addons.md
@@ -64,6 +64,7 @@ island-go: "[sound:entity_experience_orb_pickup:1:1][title]Teleporting...[subtit
 - [Boxed](../gamemodes/Boxed/index.md#translations)
 - [BSkyBlock](../gamemodes/BSkyBlock/index.md#translations)
 - [CaveBlock](../gamemodes/CaveBlock/index.md#translations)
+- [ChunkBlock](../gamemodes/ChunkBlock/index.md#translations)
 - [Poseidon](../gamemodes/Poseidon/index.md#translations)
 - [SkyGrid](../gamemodes/SkyGrid/index.md#translations)
 - [Stranger Realms](../gamemodes/StrangerRealms/index.md#translations)

--- a/docs/gamemodes/Comparison.md
+++ b/docs/gamemodes/Comparison.md
@@ -12,6 +12,7 @@ You can also run **more than one** at the same time — many servers offer two o
 |---|---|---|---|---|
 | **BSkyBlock** | Sky (floating islands) | Medium | Expand from a tiny island in the void | Medium |
 | **AOneBlock** | Sky (void) | Medium | Mine a single magical block that never runs out | Low–Medium |
+| **ChunkBlock** | Sky (void, one chunk) | Medium | Mine the magic block and spend island levels to punch out the walls | Low–Medium |
 | **AcidIsland** | Sea (acid ocean) | Medium–Hard | Skyblock with dangerous acid water | Medium |
 | **CaveBlock** | Underground | Medium | Carve out space in a solid stone world | Medium |
 | **SkyGrid** | Sky (scattered blocks) | Hard | Collect resources from a grid of single blocks | Low |
@@ -29,6 +30,9 @@ You can also run **more than one** at the same time — many servers offer two o
 
 ### I want something fresh but still approachable
 **AOneBlock** — The concept (one magical block) is easy to explain and immediately engaging. The built-in phase progression keeps players motivated for a long time.
+
+### I want the one-block loop with a reason to keep levelling
+**ChunkBlock** — The same magic block as AOneBlock (phase files are interchangeable), but the world is one 16×16 chunk behind a border nothing can cross. Island level is the currency: build your level up, walk to the wall, and punch it in the direction you want to grow. Lose levels and the newest chunks re-lock, builds untouched, until you earn them back — or switch that off in the config if you want territory to be a ratchet. Requires the [Level](../addons/Level/index.md) addon.
 
 ### I want Skyblock but harder
 **AcidIsland** — Same feel as BSkyBlock but falling in the ocean is genuinely dangerous. Good for players who found regular Skyblock too easy.
@@ -57,21 +61,25 @@ You can also run **more than one** at the same time — many servers offer two o
 
 Most BentoBox addons work with all game modes. A few have specific compatibility requirements.
 
-| Feature | BSkyBlock | AOneBlock | AcidIsland | CaveBlock | SkyGrid | Boxed | Poseidon | StrangerRealms | TradeWinds |
-|---|:---:|:---:|:---:|:---:|:---:|:---:|:---:|:---:|:---:|
-| Level addon | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ |
-| Challenges | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ |
-| Warps | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ |
-| InvSwitcher | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ |
-| Border addon | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ❌* | ✅ |
-| Nether world | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ❌** | ❌*** |
-| End world | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ❌*** |
+| Feature | BSkyBlock | AOneBlock | ChunkBlock | AcidIsland | CaveBlock | SkyGrid | Boxed | Poseidon | StrangerRealms | TradeWinds |
+|---|:---:|:---:|:---:|:---:|:---:|:---:|:---:|:---:|:---:|:---:|
+| Level addon | ✅ | ✅ | ⚠️**** | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ |
+| Challenges | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ |
+| Warps | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ |
+| InvSwitcher | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ |
+| Border addon | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ❌* | ✅ |
+| Nether world | ✅ | ✅ | ⚠️***** | ✅ | ✅ | ✅ | ✅ | ✅ | ❌** | ❌*** |
+| End world | ✅ | ✅ | ⚠️***** | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ❌*** |
 
 \* StrangerRealms has its own built-in border system — do not use the Border addon with it.
 
 \*\* StrangerRealms replaces the Nether with the Upside Down dimension.
 
 \*\*\* TradeWinds replaces the Nether with the Interstice (a hostile nether sea reached by warp misjumps) and deliberately has no End world. TradeWinds also requires Vault plus an economy plugin.
+
+\*\*\*\* ChunkBlock **requires** the Level addon — island level is the currency used to claim chunks, and ChunkBlock disables itself if Level is missing.
+
+\*\*\*\*\* ChunkBlock generates the Nether and the End off by default. Enable either one and it gets its own centre chunk and the same level-driven claim rules; the magic block only ever exists in the overworld.
 
 ---
 

--- a/docs/gamemodes/Comparison.md
+++ b/docs/gamemodes/Comparison.md
@@ -18,6 +18,7 @@ You can also run **more than one** at the same time — many servers offer two o
 | **Boxed** | Normal world | Easy–Medium | Complete advancements to grow your confined space | Medium |
 | **Poseidon** | Ocean | Medium | Survive entirely underwater | Medium |
 | **StrangerRealms** | Overworld + Upside Down | Medium–Hard | Claim land while managing a dangerous mirror dimension | Medium–High |
+| **TradeWinds** | Sea (endless trading ocean) | Easy–Hard (by region) | Sail between NPC trading islands, buying low and selling high | Medium |
 
 ---
 
@@ -47,25 +48,30 @@ You can also run **more than one** at the same time — many servers offer two o
 ### I want a story-inspired experience with complex mechanics
 **StrangerRealms** — The Upside Down mirror dimension adds a layer of strategy. Better suited to players who are comfortable with Minecraft and ready for something more involved.
 
+### I want an economy-driven trading game
+**TradeWinds** — Buy low and sell high across an endless procedurally generated ocean of NPC trading ports. Difficulty is geography: the waters near spawn are patrolled and calm, while contraband, pirates, and PvP bounty space are all further out — so it works for a family server and a cut-throat one at the same time. Requires Vault and an economy plugin.
+
 ---
 
 ## Feature Support by Game Mode
 
 Most BentoBox addons work with all game modes. A few have specific compatibility requirements.
 
-| Feature | BSkyBlock | AOneBlock | AcidIsland | CaveBlock | SkyGrid | Boxed | Poseidon | StrangerRealms |
-|---|:---:|:---:|:---:|:---:|:---:|:---:|:---:|:---:|
-| Level addon | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ |
-| Challenges | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ |
-| Warps | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ |
-| InvSwitcher | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ |
-| Border addon | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ❌* |
-| Nether world | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ❌** |
-| End world | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ |
+| Feature | BSkyBlock | AOneBlock | AcidIsland | CaveBlock | SkyGrid | Boxed | Poseidon | StrangerRealms | TradeWinds |
+|---|:---:|:---:|:---:|:---:|:---:|:---:|:---:|:---:|:---:|
+| Level addon | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ |
+| Challenges | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ |
+| Warps | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ |
+| InvSwitcher | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ |
+| Border addon | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ❌* | ✅ |
+| Nether world | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ❌** | ❌*** |
+| End world | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ❌*** |
 
 \* StrangerRealms has its own built-in border system — do not use the Border addon with it.
 
 \*\* StrangerRealms replaces the Nether with the Upside Down dimension.
+
+\*\*\* TradeWinds replaces the Nether with the Interstice (a hostile nether sea reached by warp misjumps) and deliberately has no End world. TradeWinds also requires Vault plus an economy plugin.
 
 ---
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -11,7 +11,7 @@ hide:
 <div class="bb-hero">
   <p class="bb-hero__eyebrow">docs.bentobox.world</p>
   <h1>Your players are going to have a great time.</h1>
-  <p>BSkyBlock, AOneBlock, AcidIsland, CaveBlock, SkyGrid, Boxed, Poseidon, Stranger Realms, TradeWinds — all running side by side on your Paper server, each with its own world, rules, and progression. One plugin. Drop in the game modes you want.</p>
+  <p>BSkyBlock, AOneBlock, ChunkBlock, AcidIsland, CaveBlock, SkyGrid, Boxed, Poseidon, Stranger Realms, TradeWinds — all running side by side on your Paper server, each with its own world, rules, and progression. One plugin. Drop in the game modes you want.</p>
 
   <div class="bb-cta-row">
     <a href="BentoBox/First-Steps" class="bb-btn bb-btn-primary">First 30 minutes &rarr;</a>
@@ -30,7 +30,7 @@ hide:
       <div class="bb-stat__l">addons</div>
     </div>
     <div class="bb-stat">
-      <div class="bb-stat__n">9</div>
+      <div class="bb-stat__n">10</div>
       <div class="bb-stat__l">game modes</div>
     </div>
     <div class="bb-stat">
@@ -62,7 +62,7 @@ hide:
         <span class="bb-step-time">5 min</span>
       </div>
       <p class="bb-step-title">Pick a game mode</p>
-      <p class="bb-step-body">BSkyBlock, AOneBlock, AcidIsland, CaveBlock, Boxed, Poseidon, TradeWinds &mdash; pick one to start.</p>
+      <p class="bb-step-body">BSkyBlock, AOneBlock, ChunkBlock, AcidIsland, CaveBlock, Boxed, Poseidon, TradeWinds &mdash; pick one to start.</p>
       <a href="gamemodes/Comparison" class="bb-step-link">Compare game modes &rarr;</a>
     </div>
     <div class="bb-step-card">
@@ -95,6 +95,10 @@ hide:
     <a href="gamemodes/AOneBlock/" class="bb-mode-card">
       <span class="bb-mode-swatch" style="background:#e8d49e"></span>
       <span><span class="bb-mode-name">AOneBlock</span><span class="bb-mode-sub">one block</span></span>
+    </a>
+    <a href="gamemodes/ChunkBlock/" class="bb-mode-card">
+      <span class="bb-mode-swatch" style="background:#d99a6c"></span>
+      <span><span class="bb-mode-name">ChunkBlock</span><span class="bb-mode-sub">one block &middot; walled</span></span>
     </a>
     <a href="gamemodes/CaveBlock/" class="bb-mode-card">
       <span class="bb-mode-swatch" style="background:#a09689"></span>

--- a/docs/index.md
+++ b/docs/index.md
@@ -11,7 +11,7 @@ hide:
 <div class="bb-hero">
   <p class="bb-hero__eyebrow">docs.bentobox.world</p>
   <h1>Your players are going to have a great time.</h1>
-  <p>BSkyBlock, AOneBlock, AcidIsland, CaveBlock, SkyGrid, Boxed, Poseidon, Stranger Realms — all running side by side on your Paper server, each with its own world, rules, and progression. One plugin. Drop in the game modes you want.</p>
+  <p>BSkyBlock, AOneBlock, AcidIsland, CaveBlock, SkyGrid, Boxed, Poseidon, Stranger Realms, TradeWinds — all running side by side on your Paper server, each with its own world, rules, and progression. One plugin. Drop in the game modes you want.</p>
 
   <div class="bb-cta-row">
     <a href="BentoBox/First-Steps" class="bb-btn bb-btn-primary">First 30 minutes &rarr;</a>
@@ -30,7 +30,7 @@ hide:
       <div class="bb-stat__l">addons</div>
     </div>
     <div class="bb-stat">
-      <div class="bb-stat__n">8</div>
+      <div class="bb-stat__n">9</div>
       <div class="bb-stat__l">game modes</div>
     </div>
     <div class="bb-stat">
@@ -62,7 +62,7 @@ hide:
         <span class="bb-step-time">5 min</span>
       </div>
       <p class="bb-step-title">Pick a game mode</p>
-      <p class="bb-step-body">BSkyBlock, AOneBlock, AcidIsland, CaveBlock, Boxed, Poseidon &mdash; pick one to start.</p>
+      <p class="bb-step-body">BSkyBlock, AOneBlock, AcidIsland, CaveBlock, Boxed, Poseidon, TradeWinds &mdash; pick one to start.</p>
       <a href="gamemodes/Comparison" class="bb-step-link">Compare game modes &rarr;</a>
     </div>
     <div class="bb-step-card">
@@ -115,6 +115,10 @@ hide:
     <a href="gamemodes/StrangerRealms/" class="bb-mode-card">
       <span class="bb-mode-swatch" style="background:#cf6e72"></span>
       <span><span class="bb-mode-name">StrangerRealms</span><span class="bb-mode-sub">mystery</span></span>
+    </a>
+    <a href="gamemodes/TradeWinds/" class="bb-mode-card">
+      <span class="bb-mode-swatch" style="background:#8fcabe"></span>
+      <span><span class="bb-mode-name">TradeWinds</span><span class="bb-mode-sub">sea trading</span></span>
     </a>
   </div>
 </div>


### PR DESCRIPTION
Both ChunkBlock (#89, #90) and TradeWinds (#87, #88) have full documentation sections and nav entries, but neither was reachable from any page that *enumerates* game modes — including the homepage. A visitor landing on docs.bentobox.world sees eight game modes and has no hint the other two exist.

This wires both into every such page.

## Homepage (`docs/index.md`)

- Added to the hero paragraph and the "Pick a game mode" step card
- A mode card each in the game modes grid — ChunkBlock sits next to AOneBlock (shared magic-block engine), TradeWinds at the end
- Game-modes stat bumped 8 → 10

## Choosing a Game Mode (`gamemodes/Comparison.md`)

- Quick-comparison rows for both
- A "Which should I choose?" entry each
- Both added as columns in the feature-support table

ChunkBlock's cells follow the addon's own config and docs:

- **Level addon** ⚠️ — *required*, not merely supported; island level is the currency for claiming chunks and ChunkBlock disables itself if Level is absent
- **Nether / End** ⚠️ — both `generate` off by default; enabling either gives it its own centre chunk under the same level-driven claim rules
- **Border addon** ✅ — compatible; it draws the island protection limit while ChunkBlock draws the chunk frontier inside it

TradeWinds keeps the footnote from #87 covering the Interstice, the deliberate absence of an End world, and the Vault requirement.

## Other index pages

| Page | Added |
|---|---|
| `About/GameModes.md` | A full description section for each, in the house format |
| `About/Addons.md` | Rows in the game mode addons table |
| `Translate-BentoBox-and-addons.md` | Links to each mode's translations anchor |

## Verification

`mkdocs build` completes with exit 0 and the built `site/index.html` and `site/gamemodes/Comparison/index.html` contain the new entries. All eight rows of the feature-support table have matching column counts.

`--strict` aborts, but only on eight pre-existing `translations(): GitHub listing returned 403` warnings — the macro hitting the unauthenticated rate limit on this machine. Unrelated to these changes; a build host with `GITHUB_TOKEN` set will not see them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NbnUebf6zh8aW9UmoBv7h6