### PR TITLE
docs(AOneBlock): add an FAQ for stopping visitors mining the magic block

### DIFF
--- a/docs/gamemodes/AOneBlock/index.md
+++ b/docs/gamemodes/AOneBlock/index.md
@@ -540,6 +540,37 @@ By default, BentoBox GameMode addons comes with [default placeholders set](../..
 ??? question "My magic block is liquid! How can I mine it?"
     Use a bucket.
 
+??? question "How do I stop visitors mining other players' magic blocks?"
+    This option already exists — you do not need a new config setting. If visitors are mining someone else's block, that island's owner has set the `Break Blocks` and `Magic Block` protection settings to allow it. The fix is to reset those settings across the world and then hide the icons so owners cannot turn them back on.
+
+    Do these steps **in this order**, or step 3 will undo step 1.
+
+    **1. Set the defaults for new islands**
+
+    Run `/oba settings` and open the **Island Defaults** tab (the cracked stone bricks icon). Left-click `Break Blocks` and `Magic Block` until both read **Member**. This saves to the AOneBlock `config.yml` automatically.
+
+    **2. Reload**
+
+    Run `/bbox reload`, or restart the server.
+
+    **3. Apply those defaults to all existing islands**
+
+    ```
+    /oba resetflags BREAK_BLOCKS
+    /oba resetflags MAGIC_BLOCK
+    ```
+
+    Confirm each one. This overwrites whatever every island currently has with the default you set in step 1, so it must come after step 1.
+
+    **4. Hide the settings so owners cannot change them back**
+
+    As an Op, stand on an island, run `/ob settings`, and SHIFT-LEFT-CLICK `Break Blocks` and `Magic Block`. Each one gains a Curse of Vanishing glow, meaning it is now hidden. Ops still see it; everyone else no longer has the icon in their panel at all.
+
+    Every island will now refuse anyone below Member rank breaking blocks, including the magic block, and players cannot change it.
+
+    !!! tip
+        SHIFT-LEFT-CLICK hides *any* protection setting this way, per world, and the hidden list is saved to the game mode's config. SHIFT-LEFT-CLICK a hidden setting again to bring it back.
+
 ??? question "Which mobs can spawn?"
     Each phase has a different set of mobs that can spawn. Be careful because they may push you off! If you listen carefully, you may hear hostile mobs coming.
 


### PR DESCRIPTION
[AOneBlock#554](https://github.com/BentoBoxWorld/AOneBlock/issues/554) asked for a config option to stop non-members mining the magic block. The option already exists — it is the `BREAK_BLOCKS` and `MAGIC_BLOCK` protection flags — so the answer is a procedure, not a feature. This captures tastybento's reply from the issue as an FAQ entry on the AOneBlock page, next to the other magic-block questions.

## On the ordering

The steps are order-dependent: `resetflags` overwrites every island with whatever the config default currently is, so setting the Island Defaults has to come first. The entry says so explicitly. The original reply's numbering ran 1, 1, 2, 2, 3, which made it easy to read the reset as coming first — doing it in that order resets every island to the *old* value.

## Verified against BentoBox source

Rather than transcribing the reply, each claim was checked:

| Claim | Source |
|---|---|
| `resetflags` takes one flag ID and confirms before resetting all islands in the world | `AdminResetFlagsCommand` — options are filtered to `PROTECTION` and `SETTING` types, so `BREAK_BLOCKS` and `MAGIC_BLOCK` are both valid arguments |
| SHIFT-LEFT-CLICK hides a setting, is op-only, and persists | `CycleClick#leftShiftClick` — op-gated, toggles the per-world hidden-flag list, then calls `saveWorldSettings()` |
| The Island Defaults tab is the cracked stone bricks icon | `AdminSettingsCommand` tab 3 is `IslandDefaultSettingsTab`, icon `CRACKED_STONE_BRICKS` |

A short tip was added noting that SHIFT-LEFT-CLICK works for any protection setting, is per-world, and that shift-clicking a hidden setting again brings it back — all of which follow from the same method.

## Not included

The screenshot from the issue is a GitHub `user-attachments` URL, which is fragile to hotlink from the docs site. The text describes the Curse of Vanishing glow instead.

## Verification

`mkdocs build` completes with exit 0 and the entry renders as a collapsible `<details>` block with its code fence and tip admonition intact. The only warnings are the pre-existing `translations(): GitHub listing returned 403` rate-limit messages, unrelated to this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NbnUebf6zh8aW9UmoBv7h6