### PR TITLE
Fix Maven repository URL in addon tutorial

### DIFF
--- a/docs/Tutorials/api/Create-an-addon.md
+++ b/docs/Tutorials/api/Create-an-addon.md
@@ -34,7 +34,7 @@ Add the following to your `pom.xml` file.
 <repositories>
   <repository>
     <id>codemc-repo</id>
-    <url>https://repo.codemc.org/repository/maven-public/</url>
+    <url>https://repo.codemc.io/repository/bentoboxworld/</url>
   </repository>
 </repositories>
 
@@ -54,7 +54,7 @@ Add the following to your `build.gradle` file.
 
 ```groovy
 repositories {
-  maven { url "https://repo.codemc.org/repository/maven-public/" }
+  maven { url "https://repo.codemc.io/repository/bentoboxworld/" }
 }
 
 dependencies {


### PR DESCRIPTION
## Summary
- The addon development tutorial pointed to `repo.codemc.org/repository/maven-public/` which only has old 2.x versions of BentoBox
- Updated both Maven and Gradle examples to use `repo.codemc.io/repository/bentoboxworld/` where all 3.x releases are published

Fixes BentoBoxWorld/BentoBox#3045

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Awc7WJZRNXwXGDMUfzUYFx