### PR TITLE
Add AI Policy page

### DIFF
--- a/docs/BentoBox/AI-Policy.md
+++ b/docs/BentoBox/AI-Policy.md
@@ -1,0 +1,45 @@
+# AI Policy
+
+_Last updated: 14 August 2026_
+
+This page covers how the BentoBox project uses AI, and what we expect from contributors who use it. It applies to all repositories in the BentoBoxWorld organization. The canonical [AI policy](https://github.com/BentoBoxWorld/.github/blob/master/AI_POLICY.md) lives in the BentoBoxWorld GitHub organization; this page is the same information, kept alongside the rest of the documentation.
+
+## Where we stand
+
+We are pro-AI.
+
+BentoBox's mission is to enable players to have fun. That is our metric and our goal. BentoBox is free and open source, and we measure ourselves by whether players have fun and whether server admins can enable that fun — which means the code needs to be as bug-free, efficient, and available as we can make it. We use AI tools because they accelerate that mission.
+
+BentoBox accepts sponsorships and money from listing sites. That income goes toward the project's costs: servers, hosting, and tools — including the AI tools described here.
+
+## How the project uses AI
+
+The maintainers currently use **Claude Code** and sometimes **GitHub Copilot**. The specific tools may change in the future. We use them to generate code, review code, debug code, and find problems. They are part of the BentoBox team, and their work is held to the same standard as anyone else's: it ships when it serves the mission, and not before.
+
+## Contributions
+
+### Code (pull requests)
+
+Anyone contributing to BentoBox can use AI tools. There is no restriction or limitation.
+
+PRs are always welcome — but if they are rubbish, they will be rejected, and if they need changes, changes will be asked for. That has nothing to do with AI; it is true of every PR.
+
+If you used AI, feel free to tell us — we will assume you did anyway. What matters is that **you can stand behind your code**: you understand what it does, you can answer questions about it in review, and you can fix it when asked — at least until it is accepted.
+
+### Translations
+
+Do **not** submit AI-generated translations on their own. We can make those ourselves.
+
+We only want a translation PR from you if you are actually a native speaker of the language. You are welcome to use AI to help produce the translation even as a native speaker — but only submit it if you are one, because the value you add is knowing whether it reads right.
+
+### Bug reports and feature requests
+
+AI-generated issues are fine, as of today. If they become onerous, this may change.
+
+## Licensing and conduct
+
+Contributions are accepted under the project's license, [EPL-2.0](https://github.com/BentoBoxWorld/BentoBox/blob/develop/LICENSE), whether or not AI was involved in producing them — so only contribute code you have the right to contribute. The [Code of Conduct](https://github.com/BentoBoxWorld/.github/blob/master/CODE_OF_CONDUCT.md) applies to all participation, human and AI-assisted alike. See also the [contributing guide](https://github.com/BentoBoxWorld/.github/blob/master/CONTRIBUTING.md).
+
+## Changes
+
+This whole policy can change at any time. Changes are made via pull request to the [organization repository](https://github.com/BentoBoxWorld/.github), so the file's Git history is its changelog. Questions: open an issue on [BentoBoxWorld/BentoBox](https://github.com/BentoBoxWorld/BentoBox/issues) or ask on [Discord](https://discord.bentobox.world).

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -17,6 +17,7 @@ nav:
     - Glossary: Glossary.md
     - FAQ: FAQ.md
     - Privacy: BentoBox/Privacy.md
+    - AI Policy: BentoBox/AI-Policy.md
     - Game Modes:
         - Choosing a Game Mode: gamemodes/Comparison.md
         - AcidIsland: gamemodes/AcidIsland/index.md


### PR DESCRIPTION
Stacked on #95 (both PRs insert adjacent nav lines in `mkdocs.yml`; GitHub will retarget this PR to `master` when #95 merges).

Adds `docs/BentoBox/AI-Policy.md` with a top-level **AI Policy** nav entry after Privacy, mirroring the canonical org policy in BentoBoxWorld/.github#15:

- Pro-AI stance and the mission framing (players having fun is the metric; sponsorship income goes to project costs including tools)
- Tools the maintainers use (Claude Code, sometimes Copilot; may change) and what for
- Contribution rules: unrestricted AI use for code PRs as long as the contributor can stand behind the work; translation PRs from native speakers only; AI-generated issues fine for now
- EPL-2.0 / Code of Conduct / contributing-guide links, and the policy-can-change-at-any-time note

`mkdocs build --strict` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XkVFZoe4hB2Req885z5ea7